### PR TITLE
Add opus and sonnet env presets

### DIFF
--- a/envs/espionage/opus40.env
+++ b/envs/espionage/opus40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/espionage.config.json
+export NARRATIVE_LEARNING_DATABASE=results/espionage-opus40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.espionage.opus40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/espionage-opus40.sql

--- a/envs/espionage/opus4010.env
+++ b/envs/espionage/opus4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/espionage.config.json
+export NARRATIVE_LEARNING_DATABASE=results/espionage-opus4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.espionage.opus4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/espionage-opus4010.sql

--- a/envs/espionage/sonnet40.env
+++ b/envs/espionage/sonnet40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/espionage.config.json
+export NARRATIVE_LEARNING_DATABASE=results/espionage-sonnet40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.espionage.sonnet40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/espionage-sonnet40.sql

--- a/envs/espionage/sonnet4010.env
+++ b/envs/espionage/sonnet4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/espionage.config.json
+export NARRATIVE_LEARNING_DATABASE=results/espionage-sonnet4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.espionage.sonnet4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/espionage-sonnet4010.sql

--- a/envs/potions/opus40.env
+++ b/envs/potions/opus40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/potions.config.json
+export NARRATIVE_LEARNING_DATABASE=results/potions-opus40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.potions.opus40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/potions-opus40.sql

--- a/envs/potions/opus4010.env
+++ b/envs/potions/opus4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/potions.config.json
+export NARRATIVE_LEARNING_DATABASE=results/potions-opus4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.potions.opus4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/potions-opus4010.sql

--- a/envs/potions/sonnet40.env
+++ b/envs/potions/sonnet40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/potions.config.json
+export NARRATIVE_LEARNING_DATABASE=results/potions-sonnet40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.potions.sonnet40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/potions-sonnet40.sql

--- a/envs/potions/sonnet4010.env
+++ b/envs/potions/sonnet4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/potions.config.json
+export NARRATIVE_LEARNING_DATABASE=results/potions-sonnet4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.potions.sonnet4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/potions-sonnet4010.sql

--- a/envs/southgermancredit/opus40.env
+++ b/envs/southgermancredit/opus40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/sgc_coral.config.json
+export NARRATIVE_LEARNING_DATABASE=results/sgc_coral-opus40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.sgc.opus40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/sgc_coral-opus40.sql

--- a/envs/southgermancredit/opus4010.env
+++ b/envs/southgermancredit/opus4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/sgc_coral.config.json
+export NARRATIVE_LEARNING_DATABASE=results/sgc_coral-opus4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.sgc.opus4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/sgc_coral-opus4010.sql

--- a/envs/southgermancredit/sonnet40.env
+++ b/envs/southgermancredit/sonnet40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/sgc_coral.config.json
+export NARRATIVE_LEARNING_DATABASE=results/sgc_coral-sonnet40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.sgc.sonnet40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/sgc_coral-sonnet40.sql

--- a/envs/southgermancredit/sonnet4010.env
+++ b/envs/southgermancredit/sonnet4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/sgc_coral.config.json
+export NARRATIVE_LEARNING_DATABASE=results/sgc_coral-sonnet4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.sgc.sonnet4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/sgc_coral-sonnet4010.sql

--- a/envs/timetravel_insurance/opus40.env
+++ b/envs/timetravel_insurance/opus40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/timetravel_insurance.config.json
+export NARRATIVE_LEARNING_DATABASE=results/timetravel_insurance-opus40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.timetravel_insurance.opus40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/timetravel_insurance-opus40.sql

--- a/envs/timetravel_insurance/opus4010.env
+++ b/envs/timetravel_insurance/opus4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/timetravel_insurance.config.json
+export NARRATIVE_LEARNING_DATABASE=results/timetravel_insurance-opus4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.timetravel_insurance.opus4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/timetravel_insurance-opus4010.sql

--- a/envs/timetravel_insurance/sonnet40.env
+++ b/envs/timetravel_insurance/sonnet40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/timetravel_insurance.config.json
+export NARRATIVE_LEARNING_DATABASE=results/timetravel_insurance-sonnet40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.timetravel_insurance.sonnet40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/timetravel_insurance-sonnet40.sql

--- a/envs/timetravel_insurance/sonnet4010.env
+++ b/envs/timetravel_insurance/sonnet4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/timetravel_insurance.config.json
+export NARRATIVE_LEARNING_DATABASE=results/timetravel_insurance-sonnet4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.timetravel_insurance.sonnet4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/timetravel_insurance-sonnet4010.sql

--- a/envs/titanic/opus40.env
+++ b/envs/titanic/opus40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/titanic_medical.config.json
+export NARRATIVE_LEARNING_DATABASE=results/titanic_medical-opus40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.opus40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/titanic_medical-opus40.sql

--- a/envs/titanic/opus4010.env
+++ b/envs/titanic/opus4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/titanic_medical.config.json
+export NARRATIVE_LEARNING_DATABASE=results/titanic_medical-opus4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.opus4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/titanic_medical-opus4010.sql

--- a/envs/titanic/sonnet40.env
+++ b/envs/titanic/sonnet40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/titanic_medical.config.json
+export NARRATIVE_LEARNING_DATABASE=results/titanic_medical-sonnet40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.sonnet40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/titanic_medical-sonnet40.sql

--- a/envs/titanic/sonnet4010.env
+++ b/envs/titanic/sonnet4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/titanic_medical.config.json
+export NARRATIVE_LEARNING_DATABASE=results/titanic_medical-sonnet4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.sonnet4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/titanic_medical-sonnet4010.sql

--- a/envs/wisconsin/opus40.env
+++ b/envs/wisconsin/opus40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/wisconsin_exoplanets.config.json
+export NARRATIVE_LEARNING_DATABASE=results/wisconsin_exoplanets-opus40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.wisconsin.opus40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/wisconsin_exoplanets-opus40.sql

--- a/envs/wisconsin/opus4010.env
+++ b/envs/wisconsin/opus4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/wisconsin_exoplanets.config.json
+export NARRATIVE_LEARNING_DATABASE=results/wisconsin_exoplanets-opus4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-opus-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.wisconsin.opus4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/wisconsin_exoplanets-opus4010.sql

--- a/envs/wisconsin/sonnet40.env
+++ b/envs/wisconsin/sonnet40.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/wisconsin_exoplanets.config.json
+export NARRATIVE_LEARNING_DATABASE=results/wisconsin_exoplanets-sonnet40.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.wisconsin.sonnet40
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=3
+export NARRATIVE_LEARNING_DUMP=dumps/wisconsin_exoplanets-sonnet40.sql

--- a/envs/wisconsin/sonnet4010.env
+++ b/envs/wisconsin/sonnet4010.env
@@ -1,0 +1,7 @@
+export NARRATIVE_LEARNING_CONFIG=configs/wisconsin_exoplanets.config.json
+export NARRATIVE_LEARNING_DATABASE=results/wisconsin_exoplanets-sonnet4010.sqlite
+export NARRATIVE_LEARNING_TRAINING_MODEL=claude-sonnet-4-20250514
+export NARRATIVE_LEARNING_INFERENCE_MODEL=gpt-4.1-mini
+export ROUND_TRACKING_FILE=.round-tracking-file.wisconsin.sonnet4010
+export NARRATIVE_LEARNING_EXAMPLE_COUNT=10
+export NARRATIVE_LEARNING_DUMP=dumps/wisconsin_exoplanets-sonnet4010.sql


### PR DESCRIPTION
## Summary
- add four new env files for each dataset (opus40, opus4010, sonnet40, sonnet4010)
- use gpt-4.1-mini for inference and claude-opus-4-20250514 or claude-sonnet-4-20250514 for training

## Testing
- `pytest -q`