### PR TITLE
Use env defaults in Postgres helper

### DIFF
--- a/POSTGRESQL_MIGRATION.md
+++ b/POSTGRESQL_MIGRATION.md
@@ -3,9 +3,10 @@
 This project originally stored all results in individual SQLite files. We are
 transitioning to PostgreSQL so multiple processes can share the same database
 and to simplify backups. New scripts rely on a shared helper in
-`modules/postgres.py` for creating a connection using either the `POSTGRES_DSN`
-environment variable or a JSON configuration file specified via
-`POSTGRES_CONFIG`.
+`modules/postgres.py` for creating a connection. It uses a DSN passed via
+argument or the `POSTGRES_DSN` environment variable and falls back to libpq's
+standard environment variables and defaults. A JSON configuration file path can
+also be provided through `POSTGRES_CONFIG`.
 
 Migration utilities:
 

--- a/modules/postgres.py
+++ b/modules/postgres.py
@@ -18,12 +18,11 @@ def _load_dsn_from_config(path: str) -> Optional[str]:
 
 
 def get_connection(dsn: Optional[str] = None, config_file: Optional[str] = None):
-    """Return a psycopg2 connection using env vars or a config file."""
+    """Return a psycopg2 connection using a DSN, config file or libpq defaults."""
     dsn = dsn or os.environ.get("POSTGRES_DSN")
     if not dsn:
         config_path = config_file or os.environ.get("POSTGRES_CONFIG")
         if config_path:
             dsn = _load_dsn_from_config(config_path)
-    if not dsn:
-        raise RuntimeError("PostgreSQL DSN not provided")
-    return psycopg2.connect(dsn)
+    # Fall back to libpq environment variables and defaults if no DSN is found
+    return psycopg2.connect(dsn or "")


### PR DESCRIPTION
## Summary
- simplify `modules/postgres.get_connection` so it falls back to libpq defaults
- clarify connection behaviour in PostgreSQL migration notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebb7ac278832588deb395f9e96380