### PR TITLE
Add PostgreSQL utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+This repository includes scripts that require PostgreSQL. The `envsetup.sh` script installs both the `postgresql` server and client packages so the command line tools are available. Testing or running utilities may assume that PostgreSQL is present on the system.
+
+Python commands are typically executed with the `uv` package manager. The setup script ensures `uv` is installed so `uv run` can be used for project scripts.

--- a/backup_narrative.sh
+++ b/backup_narrative.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Dump the PostgreSQL 'narrative' database to a staging file and copy it to the remote host.
+set -euo pipefail
+
+DUMP_DIR="${1:-dumps}"
+mkdir -p "$DUMP_DIR"
+
+DUMP_FILE="narrative.sql.gz"
+
+pg_dump narrative | gzip > "$DUMP_DIR/$DUMP_FILE"
+
+scp "$DUMP_DIR/$DUMP_FILE" merah.cassia.ifost.org.au:/var/www/vhosts/datadumps.ifost.org.au/htdocs/narrative-learning/

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Environment setup script for narrative-learning
+set -euo pipefail
+
+# Update package lists and install PostgreSQL
+sudo apt-get update
+sudo apt-get install -y postgresql postgresql-client
+
+# Install uv for managing Python packages
+if ! command -v uv >/dev/null 2>&1; then
+    python3 -m pip install --user uv
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Install Python dependencies with uv
+uv pip install -r requirements.txt
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- add AGENTS.md describing PostgreSQL availability
- simplify database dump script to use a fixed filename
- install PostgreSQL through `envsetup.sh`
- use `uv` to manage Python dependencies

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ed1fbc5b88325b8f211eaafc36c23