### PR TITLE
Switch training scripts to PostgreSQL

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -4,9 +4,10 @@ import sqlite3
 import sys
 import os
 import json
+import random
 import llmcall
 import datasetconfig
-import random
+from modules.postgres import get_connection, get_investigation_settings
 
 class AlreadyPredictedException(Exception):
     """Exception raised when a prediction has already been made for a specific primary key in a round.
@@ -25,7 +26,7 @@ class AlreadyPredictedException(Exception):
     def __str__(self):
         return self.message
 
-def predict(config, round_id, entity_id, model='phi4:latest', dry_run=False):
+def predict(config, round_id, entity_id, model='phi4:latest', dry_run=False, investigation_id: int | None = None):
     """
     Predict the outcome for a specific entity in a specific round.
 
@@ -44,8 +45,9 @@ def predict(config, round_id, entity_id, model='phi4:latest', dry_run=False):
     if instructions is None:
         sys.exit(f"Round ID {round_id} not found.")
 
-    query = f"SELECT COUNT(*) FROM inferences WHERE round_id = ? AND {config.primary_key} = ?"
-    cursor.execute(query, [round_id, entity_id])
+    inf_table = f"{config.dataset}_inferences" if getattr(config, "dataset", "") else "inferences"
+    query = f"SELECT COUNT(*) FROM {inf_table} WHERE round_id = ? AND {config.primary_key} = ?"
+    config._execute(cursor, query, (round_id, entity_id))
     row = cursor.fetchone()
     if row[0] == 1:
         raise AlreadyPredictedException(entity_id, round_id)
@@ -87,15 +89,17 @@ Entity Data:
         run_info = ""
         
     # Insert the prediction into the database
-    insert_query = f"""
-        INSERT INTO inferences (round_id, {config.primary_key}, narrative_text, llm_stderr, prediction)
-        VALUES (?, ?, ?, ?, ?)
-        """
+    fields = f"round_id, {config.primary_key}, narrative_text, llm_stderr, prediction"
+    placeholders = "?, ?, ?, ?, ?"
+    if investigation_id is not None:
+        fields += ", investigation_id"
+        placeholders += ", ?"
+    insert_query = f"INSERT INTO {inf_table} ({fields}) VALUES ({placeholders})"
 
-    cursor.execute(
-            insert_query,
-            (round_id, entity_id, prediction_output['narrative_text'], run_info, prediction_output['prediction'])
-        )
+    params = [round_id, entity_id, prediction_output['narrative_text'], run_info, prediction_output['prediction']]
+    if investigation_id is not None:
+        params.append(investigation_id)
+    config._execute(cursor, insert_query, tuple(params))
     config.conn.commit()
 
 
@@ -109,10 +113,13 @@ if __name__ == '__main__':
         description="Make predictions for an entity based on the round prompt"
     )
     parser.add_argument('--database', default=default_database,
-                        required=(default_database is None),
                         help="Path to the SQLite database file")
+    parser.add_argument('--dsn', help='PostgreSQL DSN')
+    parser.add_argument('--pg-config', help='JSON file containing postgres_dsn')
     parser.add_argument('--round-id', type=int, required=True,
                         help="Round ID")
+    parser.add_argument('--investigation-id', type=int,
+                        help='ID from investigations table')
     parser.add_argument('--entity-id', required=True,
                         help="Entity ID (e.g., Patient_ID)")
     parser.add_argument("--dry-run", action="store_true",
@@ -122,12 +129,19 @@ if __name__ == '__main__':
     parser.add_argument("--config", default=default_config, help="The JSON config file that says what columns exist and what the tables are called")
     args = parser.parse_args()
 
-    if args.database is None:
-        sys.exit("Must specify --database or set the env variable NARRATIVE_LEARNING_DATABASE")
-    if args.config is None:
-        sys.exit("Must specify --config or set the env variable NARRATIVE_LEARNING_CONFIG")
+    if args.investigation_id is not None:
+        conn = get_connection(args.dsn, args.pg_config)
+        dataset, config_file = get_investigation_settings(conn, args.investigation_id)
+        config = datasetconfig.DatasetConfig(conn, config_file, dataset)
+    else:
+        if not (args.database or args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
+            sys.exit("Must specify --database or --dsn/--pg-config for PostgreSQL")
+        if args.config is None:
+            sys.exit("Must specify --config or set the env variable NARRATIVE_LEARNING_CONFIG")
+        if args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN'):
+            conn = get_connection(args.dsn, args.pg_config)
+        else:
+            conn = sqlite3.connect(args.database)
+        config = datasetconfig.DatasetConfig(conn, args.config)
 
-    conn = sqlite3.connect(args.database)
-    config = datasetconfig.DatasetConfig(conn, args.config)
-
-    predict(config, args.round_id, args.entity_id, args.model, args.dry_run)
+    predict(config, args.round_id, args.entity_id, args.model, args.dry_run, args.investigation_id)

--- a/process_round.py
+++ b/process_round.py
@@ -2,9 +2,10 @@
 import argparse
 import sqlite3
 import sys
-import predict
 import os
+import predict
 import datasetconfig
+from modules.postgres import get_connection
 
 def main():
     # One day I'll make --database mandatory, with no fallback to titanic_medical.sqlite
@@ -19,6 +20,9 @@ def main():
     parser.add_argument("--config", default=default_config, help="The JSON config file that says what columns exist and what the tables are called")
     parser.add_argument("--progress-bar", action="store_true", help="Show a progress bar")
     parser.add_argument('--database', default=default_database, help="Path to the SQLite database file")
+    parser.add_argument('--dsn', help='PostgreSQL DSN')
+    parser.add_argument('--pg-config', help='JSON file containing postgres_dsn')
+    parser.add_argument('--investigation-id', type=int, help='ID from investigations table')
     # Maybe one day I will find the latest round by default, or have an option for a split_id
     parser.add_argument("--model", default=default_model)
     args = parser.parse_args()
@@ -26,30 +30,39 @@ def main():
     if args.list and args.loop:
         sys.exit("Can't loop if we aren't going to process anything")
 
-    if args.database is None:
-        sys.exit("Must specify --database or set the env variable NARRATIVE_LEARNING_DATABASE")
-    if args.model is None and not args.list:
-        sys.exit("Must specify --model or set the env variable NARRATIVE_LEARNING_INFERENCE_MODEL")
-    if args.config is None:
-        sys.exit("Must specify --config or set the env variable NARRATIVE_LEARNING_CONFIG")
-
-    conn = sqlite3.connect(args.database)
-    cur = conn.cursor()
-    config = datasetconfig.DatasetConfig(conn, args.config)
+    if args.investigation_id is not None:
+        conn = get_connection(args.dsn, args.pg_config)
+        dataset, config_file = get_investigation_settings(conn, args.investigation_id)
+        cur = conn.cursor()
+        config = datasetconfig.DatasetConfig(conn, config_file, dataset)
+    else:
+        if not (args.database or args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
+            sys.exit("Must specify --database or --dsn/--pg-config for PostgreSQL")
+        if args.model is None and not args.list:
+            sys.exit("Must specify --model or set the env variable NARRATIVE_LEARNING_INFERENCE_MODEL")
+        if args.config is None:
+            sys.exit("Must specify --config or set the env variable NARRATIVE_LEARNING_CONFIG")
+        if args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN'):
+            conn = get_connection(args.dsn, args.pg_config)
+        else:
+            conn = sqlite3.connect(args.database)
+        cur = conn.cursor()
+        config = datasetconfig.DatasetConfig(conn, args.config)
 
 
     predictions_done = 0
 
     while True:
         # Get IDs that are not already inferred
+        inf_table = f"{config.dataset}_inferences" if getattr(config, 'dataset', '') else "inferences"
         query = f"""
         SELECT {config.primary_key}
         FROM {config.table_name}
         WHERE {config.primary_key} NOT IN (
-           SELECT {config.primary_key} FROM inferences WHERE round_id = ?
+           SELECT {config.primary_key} FROM {inf_table} WHERE round_id = ?
         );
         """
-        cur.execute(query, (args.round_id,))
+        config._execute(cur, query, (args.round_id,))
         # I think I should try doing a fetchall so that tqdm knows the appropriate length
         iterator = cur
         if args.progress_bar:
@@ -61,7 +74,7 @@ def main():
             if args.list:
                 print(row[0])
                 continue
-            predict.predict(config, args.round_id, row[0], model=args.model)
+            predict.predict(config, args.round_id, row[0], model=args.model, investigation_id=args.investigation_id)
             predictions_done += 1
             if args.stop_after is not None and predictions_done >= args.stop_after:
                 sys.exit(0)


### PR DESCRIPTION
## Summary
- update helper modules to optionally use PostgreSQL param style
- allow DatasetConfig to execute queries on PostgreSQL
- add `--dsn`/`--pg-config` options to `train.py`, `process_round.py` and `predict.py`
- look up config by investigation ID when writing to Postgres

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed83edc288325bb1ba880999748df