### PR TITLE
Automate DB restore from dump in envsetup

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -9,3 +9,23 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 uv run uvbootstrapper.py
 
+# Start PostgreSQL
+sudo service postgresql start
+
+# Ensure roles exist for the restore and for the current user
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='narrative'" | grep -q 1 || \
+  sudo -u postgres psql -c "CREATE ROLE narrative LOGIN CREATEDB"
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='root'" | grep -q 1 || \
+  sudo -u postgres psql -c "CREATE ROLE root SUPERUSER LOGIN"
+
+# Download and restore the narrative database
+DUMP_URL="https://datadumps.ifost.org.au/narrative-learning/narrative.sql.gz"
+DUMP_DIR="dumps"
+DUMP_FILE="$DUMP_DIR/narrative.sql.gz"
+mkdir -p "$DUMP_DIR"
+curl -L "$DUMP_URL" -o "$DUMP_FILE"
+
+sudo -u postgres dropdb --if-exists narrative
+sudo -u postgres createdb -O narrative narrative
+gunzip -c "$DUMP_FILE" | sudo -u postgres psql narrative
+


### PR DESCRIPTION
## Summary
- fetch latest PostgreSQL dump in `envsetup.sh`
- start the database service and ensure required roles exist
- automatically restore the `narrative` database

## Testing
- `uv pip install -r requirements.txt`
- `uv run pytest test_env_settings.py -q`
- `uv run list_empty_investigations.py --dsn "dbname=narrative user=root"`

------
https://chatgpt.com/codex/tasks/task_e_684fc4753f648325a20942287b064ef2