### PR TITLE
Add cleanup SQL and run script

### DIFF
--- a/cleanup_unrun_investigations.sql
+++ b/cleanup_unrun_investigations.sql
@@ -1,0 +1,33 @@
+-- Remove investigations that rely on ollama-backed models and
+-- reset round numbers for investigations with no inference data.
+--
+-- This script expects a temporary view ``empty_investigations(id)`` listing the
+-- investigation IDs with no SQLite inference data. Generate it using::
+--
+--   python list_empty_investigations.py --skip-ollama --print-view > empty.sql
+--   psql $DSN -f empty.sql -f cleanup_unrun_investigations.sql
+--
+-- Delete investigations using ollama-powered models that never produced data.
+DELETE FROM investigations AS i
+USING models AS m, empty_investigations AS e
+WHERE i.id = e.id
+  AND i.model = m.model
+  AND m.training_model IN (
+      'phi4:latest',
+      'llama3.3:latest',
+      'falcon3:1b',
+      'falcon3:10b',
+      'gemma2:27b',
+      'gemma2:2b',
+      'phi4-mini',
+      'deepseek-r1:70b',
+      'qwq:32b',
+      'gemma3:27b',
+      'cogito:70b'
+  );
+
+-- Clear round numbers for any investigation that has no data.
+UPDATE investigations AS i
+SET round_number = NULL
+FROM empty_investigations AS e
+WHERE i.id = e.id;

--- a/run_pending_investigations.sh
+++ b/run_pending_investigations.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Run all investigations that have no inference data, skipping
+# those that use ollama-backed models.
+#
+# Usage: POSTGRES_DSN=postgres://user@host/db ./run_pending_investigations.sh
+#        or pass the DSN as the first argument.
+set -euo pipefail
+
+DSN="${1:-${POSTGRES_DSN:-}}"
+if [ -z "$DSN" ]; then
+    echo "PostgreSQL DSN must be provided as POSTGRES_DSN or argument" >&2
+    exit 1
+fi
+
+EMPTY_IDS=$(python list_empty_investigations.py --dsn "$DSN" --skip-ollama 2>/dev/null | awk '/^[0-9]+$/')
+
+if [ -z "$EMPTY_IDS" ]; then
+    echo "No pending investigations to run." >&2
+    exit 0
+fi
+
+for id in $EMPTY_IDS; do
+    echo "Running investigation $id"
+    uv run investigate.py "$id" --dsn "$DSN"
+done


### PR DESCRIPTION
## Summary
- add SQL script to remove unused ollama investigations and reset round numbers
- add helper script to run pending investigations
- output helper view from `list_empty_investigations.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850057b4e9c8325a38d415fc35ae70b