### PR TITLE
Use postgres in report script

### DIFF
--- a/datasetconfig.py
+++ b/datasetconfig.py
@@ -26,16 +26,18 @@ class DatasetConfig:
     This class provides methods for retrieving and handling obfuscated data.
     """
 
-    def __init__(self, conn: Any, config_path: str, dataset: str = ""):
+    def __init__(self, conn: Any, config_path: str, dataset: str = "", investigation_id: Optional[int] = None):
         """
         Initialize with a database connection and configuration file path.
 
         Args:
-            conn: SQLite database connection
+            conn: SQLite or PostgreSQL database connection
             config_path: Path to the JSON configuration file
+            investigation_id: Filter rounds by this investigation when using PostgreSQL
         """
         self.conn = conn
         self.dataset = dataset
+        self.investigation_id = investigation_id
 
         # Load configuration
         with open(config_path, 'r') as f:
@@ -371,7 +373,7 @@ class DatasetConfig:
         Raises:
             SystemExit: If no rounds are found in the database
         """
-        return get_latest_split_id(self.conn, self.dataset)
+        return get_latest_split_id(self.conn, self.dataset, self.investigation_id)
 
     def get_rounds_for_split(self, split_id: int) -> List[int]:
         """
@@ -383,7 +385,7 @@ class DatasetConfig:
         Returns:
             List of round IDs
         """
-        return get_rounds_for_split(self.conn, split_id, self.dataset)
+        return get_rounds_for_split(self.conn, split_id, self.dataset, self.investigation_id)
 
     def get_processed_rounds_for_split(self, split_id: int) -> List[int]:
         """
@@ -395,7 +397,7 @@ class DatasetConfig:
         Returns:
             List of round IDs that have inferences
         """
-        return get_processed_rounds_for_split(self.conn, split_id, self.dataset)
+        return get_processed_rounds_for_split(self.conn, split_id, self.dataset, self.investigation_id)
 
     def check_early_stopping(self, split_id: int, metric: str,
                             patience: int, on_validation: bool = True) -> bool:

--- a/predict.py
+++ b/predict.py
@@ -132,7 +132,7 @@ if __name__ == '__main__':
     if args.investigation_id is not None:
         conn = get_connection(args.dsn, args.pg_config)
         dataset, config_file = get_investigation_settings(conn, args.investigation_id)
-        config = datasetconfig.DatasetConfig(conn, config_file, dataset)
+        config = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
     else:
         if not (args.database or args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
             sys.exit("Must specify --database or --dsn/--pg-config for PostgreSQL")

--- a/process_round.py
+++ b/process_round.py
@@ -34,7 +34,7 @@ def main():
         conn = get_connection(args.dsn, args.pg_config)
         dataset, config_file = get_investigation_settings(conn, args.investigation_id)
         cur = conn.cursor()
-        config = datasetconfig.DatasetConfig(conn, config_file, dataset)
+        config = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
     else:
         if not (args.database or args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
             sys.exit("Must specify --database or --dsn/--pg-config for PostgreSQL")

--- a/train.py
+++ b/train.py
@@ -131,7 +131,7 @@ def main():
     if args.investigation_id is not None:
         conn = get_connection(args.dsn, args.pg_config)
         dataset, config_file = get_investigation_settings(conn, args.investigation_id)
-        config = datasetconfig.DatasetConfig(conn, config_file, dataset)
+        config = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
     else:
         if not (args.database or args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
             sys.exit("Must specify --database or --dsn/--pg-config for PostgreSQL")


### PR DESCRIPTION
## Summary
- connect report-script to PostgreSQL via investigation id
- filter round queries by investigation id
- thread investigation id through DatasetConfig
- pass investigation id into training, prediction and round processing scripts

## Testing
- `python3 -m py_compile datasetconfig.py modules/database.py train.py predict.py process_round.py report-script.py`

------
https://chatgpt.com/codex/tasks/task_e_68579e8fd43883258c9f0d63b9dc2e57