### PR TITLE
Remove sqlite option from report-script

### DIFF
--- a/report-script.py
+++ b/report-script.py
@@ -1,20 +1,15 @@
 #!/usr/bin/env python3
 import argparse
-import sqlite3
 import sys
 import datasetconfig
 import pandas as pd
 import matplotlib.pyplot as plt
-from typing import Dict, List, Optional
 import os
 from modules.postgres import get_connection, get_investigation_settings
 
 def main():
-    default_database = os.environ.get('NARRATIVE_LEARNING_DATABASE', None)
     default_config = os.environ.get('NARRATIVE_LEARNING_CONFIG', None)
     parser = argparse.ArgumentParser(description="Report on classification metrics across rounds")
-    parser.add_argument('--database', default=default_database,
-                       help="Path to the SQLite database file")
     parser.add_argument('--dsn', help='PostgreSQL DSN')
     parser.add_argument('--pg-config', help='JSON file containing postgres_dsn')
     parser.add_argument('--investigation-id', type=int, help='ID from investigations table')
@@ -46,15 +41,10 @@ def main():
         dataset, config_file = get_investigation_settings(conn, args.investigation_id)
         config = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
     else:
-        if not (args.database or args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
-            sys.exit("Must specify --database or --dsn/--pg-config for PostgreSQL")
         if args.config is None:
             sys.exit("Must specify --config or set the env variable NARRATIVE_LEARNING_CONFIG")
 
-        if args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN'):
-            conn = get_connection(args.dsn, args.pg_config)
-        else:
-            conn = sqlite3.connect(f'file:{args.database}?mode=ro', uri=True)
+        conn = get_connection(args.dsn, args.pg_config)
         config = datasetconfig.DatasetConfig(conn, args.config)
 
     # If split_id not provided, use the most recent


### PR DESCRIPTION
## Summary
- drop `--database` flag from `report-script.py`
- rely on PostgreSQL environment variables when no DSN is provided

## Testing
- `python -m py_compile report-script.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857a1162a9483258160c0f8f274d489