### PR TITLE
Fix Postgres in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
         env:
           POSTGRES_DB: narrative
           POSTGRES_USER: root
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: >-


### PR DESCRIPTION
## Summary
- allow passwordless access for the PostgreSQL service

## Testing
- `uv pip install -r requirements.txt`
- `uv run python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_685800bb1f3483259959871bf18f8e19