### PR TITLE
Remove redundant install step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-      - name: Install dependencies
-        run: |
-          uv pip install -r requirements.txt
       - name: Run tests
         env:
           PGHOST: localhost


### PR DESCRIPTION
## Summary
- drop the unused `Install dependencies` step from CI workflow

## Testing
- `uv run python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_685802203ef88325b965e679a6eb2f79