### PR TITLE
Extend baselines and store in Postgres

### DIFF
--- a/postgres-schemas/investigations_schema.sql
+++ b/postgres-schemas/investigations_schema.sql
@@ -21,3 +21,14 @@ CREATE TABLE investigations (
     dump_file TEXT,
     round_number INTEGER DEFAULT 1
 );
+
+CREATE TABLE baseline_results (
+    dataset TEXT PRIMARY KEY REFERENCES datasets(dataset),
+    logistic_regression DOUBLE PRECISION,
+    decision_trees DOUBLE PRECISION,
+    dummy DOUBLE PRECISION,
+    rulefit DOUBLE PRECISION,
+    bayesian_rule_list DOUBLE PRECISION,
+    corels DOUBLE PRECISION,
+    ebm DOUBLE PRECISION
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas
 matplotlib
 openai
 psycopg2-binary>=2.9.9
+imodels
+interpret


### PR DESCRIPTION
## Summary
- support PostgreSQL connections for baseline generation
- add rule-based baselines using `imodels` and `interpret`
- save baseline lower bounds in a new `baseline_results` table
- include `imodels` and `interpret` in requirements

## Testing
- `pip install psycopg2-binary`
- `pip install imodels interpret`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bf2fef68832599f17a46294baf3f