### PR TITLE
Fix Postgres dataset table selection in report-script

### DIFF
--- a/report-script.py
+++ b/report-script.py
@@ -41,6 +41,8 @@ def main():
         dataset, config_file = get_investigation_settings(conn, args.investigation_id)
         config = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
     else:
+        if args.dsn or args.pg_config or os.environ.get("POSTGRES_DSN"):
+            sys.exit("Must specify --investigation-id for PostgreSQL")
         if args.config is None:
             sys.exit("Must specify --config or set the env variable NARRATIVE_LEARNING_CONFIG")
 


### PR DESCRIPTION
## Summary
- revert dataset CLI option
- require investigation ID when using PostgreSQL so the dataset prefix is discovered correctly

## Testing
- `python -m py_compile report-script.py`


------
https://chatgpt.com/codex/tasks/task_e_6858ca6b38c48325927efd931e4f9544