### PR TITLE
Fix missing dataset selection in investigation loop

### DIFF
--- a/investigate.py
+++ b/investigate.py
@@ -104,6 +104,8 @@ def main() -> None:
                 "uv",
                 "run",
                 "report-script.py",
+                "--investigation-id",
+                str(args.investigation_id),
                 "--metric",
                 "accuracy",
                 "--validation",
@@ -156,7 +158,14 @@ def main() -> None:
             (round_no, args.investigation_id),
         )
 
-    ret, best = capture_cmd(["uv", "run", "report-script.py", "--best"])
+    ret, best = capture_cmd([
+        "uv",
+        "run",
+        "report-script.py",
+        "--investigation-id",
+        str(args.investigation_id),
+        "--best",
+    ])
     if ret == 0 and best:
         outfile = sqlite_db[: -len(".sqlite")] + ".best-round.txt"
         with open(outfile, "w") as f:


### PR DESCRIPTION
## Summary
- ensure `investigate.py` passes the investigation id to `report-script.py`

## Testing
- `uv pip install -q pytest`
- `uv pip install -q psycopg2-binary`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858d680db488325af91ce3d824ff98b