### PR TITLE
Remove root fallback DSN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,6 @@ The setup script also restores a database called `narrative`. The service runs
 locally and can be accessed using the `root` role via peer authentication. You
 can inspect it with `psql -U root narrative` or connect from Python using
 `psycopg2.connect(dbname='narrative', user='root')`.
+
+When testing scripts that use libpq defaults, set the `PGUSER` environment
+variable to `root` so connections are made with the correct role.

--- a/modules/postgres.py
+++ b/modules/postgres.py
@@ -24,13 +24,9 @@ def get_connection(dsn: Optional[str] = None, config_file: Optional[str] = None)
         config_path = config_file or os.environ.get("POSTGRES_CONFIG")
         if config_path:
             dsn = _load_dsn_from_config(config_path)
-    if not dsn:
-        # Default to the local narrative database using the root role. This
-        # avoids failures when PGUSER is set to an account without peer access
-        # ("narrative" in the training environment).
-        dsn = "postgresql:///narrative?user=root"
 
-    return psycopg2.connect(dsn)
+    # If no DSN is supplied, rely on libpq environment defaults.
+    return psycopg2.connect(dsn) if dsn else psycopg2.connect()
 
 
 def get_investigation_settings(conn, investigation_id: int) -> Tuple[str, str]:


### PR DESCRIPTION
## Summary
- remove fallback DSN pointing at user `root`
- note that PGUSER should be set to `root` when testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e8ba492c8325b96b5751fe5a978f