### PR TITLE
Fix history query in training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,7 @@ uv run investigate.py <investigation-id>
 `investigate.py` reads the settings for the given investigation ID from
 PostgreSQL and updates the `round_number` field after each successful round.
 The initial value should be loaded from the `round_tracking_file` referenced in
-the `investigations` table (no loader script exists yet).
+the `investigations` table (no loader script exists yet).  Each dataset has its
+own tables such as `espionage_rounds` and `espionage_inferences`; the training
+scripts use the dataset name from the configuration to construct these table
+names.


### PR DESCRIPTION
## Summary
- fetch historical rounds using DatasetConfig helper
- respect `dataset` and `investigation_id` when querying history
- require dataset name when running the training script
- support PostgreSQL column names by not quoting identifiers
- handle boolean parameter in get_random_non_holdout_id
- document dataset-specific table names

## Testing
- `PGUSER=root uv pip install pytest`
- `PGUSER=root uv run python -m pytest -q test_postgres.py test_env_settings.py`
- `PGUSER=root PGDATABASE=narrative uv run investigation_info.py 529`


------
https://chatgpt.com/codex/tasks/task_e_6858fdac7b448325b448e9711e784f48