### PR TITLE
Add rounds_table field to configs and update code

### DIFF
--- a/configs/espionage.config.json
+++ b/configs/espionage.config.json
@@ -3,6 +3,7 @@
   "primary_key": "AgentID",
   "target_field": "AgentStatus",
   "splits_table": "espionage_splits",
+  "rounds_table": "espionage_rounds",
   "columns": [
     "AgentID",
     "SecretHandshakeQuality",

--- a/configs/potions.config.json
+++ b/configs/potions.config.json
@@ -3,6 +3,7 @@
   "primary_key": "PotionBatchID",
   "target_field": "PotionEffectiveness",
   "splits_table": "potion_splits",
+  "rounds_table": "potions_rounds",
   "columns": [
     "PotionBatchID",
     "FizzIntensity",

--- a/configs/sgc_coral.config.json
+++ b/configs/sgc_coral.config.json
@@ -3,6 +3,7 @@
   "primary_key": "CoralReefID",
   "target_field": "ReefHealthStatus",
   "splits_table": "coral_reef_splits",
+  "rounds_table": "southgermancredit_rounds",
   "columns": [
     "CoralReefID",
     "CurrentFlowQuality",

--- a/configs/timetravel_insurance.config.json
+++ b/configs/timetravel_insurance.config.json
@@ -3,6 +3,7 @@
   "primary_key": "IncidentID",
   "target_field": "PolicyClaim",
   "splits_table": "time_travel_splits",
+  "rounds_table": "timetravel_insurance_rounds",
   "columns": [
     "IncidentID",
     "TimelineDeviation",

--- a/configs/titanic_medical.config.json
+++ b/configs/titanic_medical.config.json
@@ -3,6 +3,7 @@
   "primary_key": "Patient_ID",
   "target_field": "Outcome",
   "splits_table": "patient_splits",
+  "rounds_table": "titanic_rounds",
   "columns": [
     "Outcome",
     "Patient_ID",

--- a/configs/wisconsin_exoplanets.config.json
+++ b/configs/wisconsin_exoplanets.config.json
@@ -3,6 +3,7 @@
   "primary_key": "exoplanet_id",
   "target_field": "occupying_species",
   "splits_table": "exoplanet_splits",
+  "rounds_table": "wisconsin_rounds",
   "columns": [
     "exoplanet_id",
     "mean_orbital_radius",

--- a/initialise_database.py
+++ b/initialise_database.py
@@ -189,15 +189,17 @@ def apply_transformation(original_df, obfuscation_plan):
         result = exec(column_info["transformation"])
     return obfuscated_df
 
-def create_config_file(output_path, obfuscation_plan):
+def create_config_file(output_path, obfuscation_plan, dataset_prefix: str = ""):
     # Get a list of all columns in the transformed dataset for reference
     column_lookup = { x['original_column']: x['obfuscated_column'] for x in obfuscation_plan['columns'] }
 
+    rounds_table = f"{dataset_prefix}_rounds" if dataset_prefix else "rounds"
     config = {
         "table_name": obfuscation_plan['obfuscated_table_name'],
         "primary_key": column_lookup[obfuscation_plan['primary_key']],
         "target_field": column_lookup[obfuscation_plan['target_variable']],
-        "splits_table": obfuscation_plan['obfuscated_split_table_name']
+        "splits_table": obfuscation_plan['obfuscated_split_table_name'],
+        "rounds_table": rounds_table
     }
     config["columns"] = [col['obfuscated_column'] for col in obfuscation_plan['columns'] if not col['remove']]
     
@@ -327,7 +329,7 @@ def main():
         print(f"Target field identified as: {target_field}")
 
     
-    config_path = create_config_file(args.config_file, obfuscation_plan)
+    config_path = create_config_file(args.config_file, obfuscation_plan, dataset_prefix)
     
     if args.verbose:
         print(f"Database initialized successfully with table '{obfuscated_table_name}'!")

--- a/investigate.py
+++ b/investigate.py
@@ -84,6 +84,10 @@ def main() -> None:
         dump_path,
     ) = row
 
+    with open(config) as f:
+        config_json = json.load(f)
+    rounds_table = config_json.get("rounds_table", f"{dataset}_rounds")
+
     env = {
         "NARRATIVE_LEARNING_CONFIG": config,
         "NARRATIVE_LEARNING_DATABASE": sqlite_db,
@@ -102,18 +106,18 @@ def main() -> None:
 
     # Ensure there is at least one round for this investigation.
     cur.execute(
-        f"SELECT 1 FROM {dataset}_rounds WHERE investigation_id=%s LIMIT 1",
+        f"SELECT 1 FROM {rounds_table} WHERE investigation_id=%s LIMIT 1",
         (args.investigation_id,),
     )
     if cur.fetchone() is None:
-        cur.execute(f"SELECT COALESCE(max(round_id), 0) + 1 FROM {dataset}_rounds")
+        cur.execute(f"SELECT COALESCE(max(round_id), 0) + 1 FROM {rounds_table}")
         next_id = cur.fetchone()[0]
         cur.execute(
-            f"SELECT setval('{dataset}_rounds_round_id_seq', %s, true)",
+            f"SELECT setval('{rounds_table}_round_id_seq', %s, true)",
             (next_id,),
         )
         cur.execute(
-            f"INSERT INTO {dataset}_rounds (round_id, split_id, prompt, investigation_id) VALUES (%s, 0, 'Choose randomly', %s)",
+            f"INSERT INTO {rounds_table} (round_id, split_id, prompt, investigation_id) VALUES (%s, 0, 'Choose randomly', %s)",
             (next_id, args.investigation_id),
         )
 

--- a/train.py
+++ b/train.py
@@ -41,9 +41,7 @@ would handle one of those situations correctly.
     # History rounds (without examples)
     if history_rounds > 0:
         cur = config.conn.cursor()
-        if not getattr(config, "dataset", ""):
-            raise RuntimeError("Dataset name must be provided")
-        table = f"{config.dataset}_rounds"
+        table = config.rounds_table
         query = f"""
             SELECT round_id, prompt
               FROM {table}
@@ -98,9 +96,7 @@ def run_reprompt(config, prompting_creation_prompt, old_round_id, model, verbose
     if verbose:
         print(f"Quality control passed the following prompt:\n\n```\n{new_prompt}\n```")
     cur = config.conn.cursor()
-    if not getattr(config, "dataset", ""):
-        raise RuntimeError("Dataset name must be provided")
-    table = f"{config.dataset}_rounds"
+    table = config.rounds_table
     fields = "split_id, prompt, reasoning_for_this_prompt, stderr_from_prompt_creation"
     placeholders = "?, ?, ?, ?"
     params = [split_id, new_prompt['updated_prompt'], new_prompt['reasoning'], process_info]


### PR DESCRIPTION
## Summary
- embed `rounds_table` in every dataset config
- respect `rounds_table` in DatasetConfig
- create `rounds_table` when generating configs
- use new config entry in `train.py` and `investigate.py`
- fix random data generator to support dataset-specific rounds tables

## Testing
- `python3 -m py_compile datasetconfig.py train.py investigate.py random_classification_data_generator.py initialise_database.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5b151a588325972ebcae88d86026