### PR TITLE
Fix split table for Titanic investigations

### DIFF
--- a/configs/titanic_medical.config.json
+++ b/configs/titanic_medical.config.json
@@ -2,7 +2,7 @@
   "table_name": "patients",
   "primary_key": "Patient_ID",
   "target_field": "Outcome",
-  "splits_table": "patient_split_ids",
+  "splits_table": "patient_splits",
   "rounds_table": "titanic_rounds",
   "columns": [
     "Outcome",


### PR DESCRIPTION
## Summary
- point Titanic config at the proper `patient_splits` table
- load the splits table name in `investigate.py`
- when bootstrapping an investigation, insert the first round with the lowest
  available split id

## Testing
- `pip install psycopg2-binary`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3e749b188325b69dc9450fc6a4ae