### PR TITLE
Update setup documentation and envscript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 This repository includes scripts that require PostgreSQL. The `envsetup.sh` script installs both the `postgresql` server and client packages so the command line tools are available. Testing or running utilities may assume that PostgreSQL is present on the system.
 
-Python commands are typically executed with the `uv` package manager. The setup script ensures `uv` is installed so `uv run` can be used for project scripts.
+Python commands are typically executed with the `uv` package manager. The setup script ensures `uv` is installed so `uv run` can be used for project scripts. When you run a script with `uv run`, it automatically installs any dependencies declared in `pyproject.toml` or `uv.lock`, so manual package installation is usually unnecessary.
 
 The setup script also restores a database called `narrative`. The service runs
 locally and can be accessed using the `root` role via peer authentication. You

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Update package lists and install PostgreSQL
 sudo apt-get update
-sudo apt-get install -y postgresql postgresql-client
+sudo apt-get install -y postgresql postgresql-client python3-psycopg2
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 uv run uvbootstrapper.py


### PR DESCRIPTION
## Summary
- remind that `uv run` installs dependencies for you
- ensure `envsetup.sh` installs `psycopg2` via apt

## Testing
- `uv run python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_685b7091e0448325859ee5cf050d866f