### PR TITLE
Add SQL updates to round checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ three tables:
 * `models` – training and inference model names with optional `example_count`
   and `patience` values
 * `investigations` – links a dataset and model, records the `sqlite_database`,
-  `round_tracking_file`, optional `dump_file` and the current `round_number`
+  `round_tracking_file`, optional `dump_file` and the current `round_number`.
+  New investigations no longer default to round 1 – the value should be set
+  explicitly from the associated round tracking file.
 
 Load the schema and initial data with:
 
@@ -115,3 +117,12 @@ the `investigations` table (no loader script exists yet).  Each dataset has its
 own tables such as `espionage_rounds` and `espionage_inferences`; the training
 scripts use the dataset name from the configuration to construct these table
 names.
+
+The `check_round_consistency.py` helper reports how many investigations have a
+`round_number` that does not match an entry in the relevant `*_rounds` table.
+It also prints `UPDATE` statements to correct the values.
+Run it with libpq environment variables set, for example:
+
+```bash
+PGUSER=root PGDATABASE=narrative ./check_round_consistency.py
+```

--- a/check_round_consistency.py
+++ b/check_round_consistency.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Check and repair investigations.round_number values.
+
+For each dataset, the corresponding ``*_rounds`` table holds a ``round_id`` for
+every round of training. The ``investigations.round_number`` column should equal
+the most recent ``round_id`` for that investigation.
+
+This helper prints how many investigations are out of sync and outputs ``UPDATE``
+statements to fix them.
+"""
+from __future__ import annotations
+
+import json
+from modules.postgres import get_connection
+
+
+def main() -> None:
+    conn = get_connection()
+    cur = conn.cursor()
+
+    cur.execute("SELECT dataset, config_file FROM datasets")
+    dataset_cfg_files = dict(cur.fetchall())
+
+    # Map dataset -> rounds_table from config
+    round_tables: dict[str, str] = {}
+    for dataset, cfg_path in dataset_cfg_files.items():
+        with open(cfg_path, "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+        round_tables[dataset] = cfg.get("rounds_table", f"{dataset}_rounds")
+
+    for dataset, table in round_tables.items():
+        cur.execute(
+            f"""
+            SELECT i.id, i.round_number, MAX(r.round_id) AS max_round
+              FROM investigations i
+              LEFT JOIN {table} r ON i.id = r.investigation_id
+             WHERE i.dataset = %s
+             GROUP BY i.id, i.round_number
+            """,
+            (dataset,),
+        )
+        rows = cur.fetchall()
+
+        mismatches = [r for r in rows if (r[2] or 0) != r[1]]
+        print(f"{dataset}: {len(mismatches)} mismatches")
+
+        for inv_id, round_no, max_round in mismatches:
+            correct = max_round or 0
+            print(
+                f"-- investigation {inv_id}: found max round {correct} (currently {round_no})"
+            )
+            print(
+                f"UPDATE investigations SET round_number={correct} WHERE id={inv_id};"
+            )
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/postgres-schemas/investigations_schema.sql
+++ b/postgres-schemas/investigations_schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE investigations (
     sqlite_database TEXT,
     round_tracking_file TEXT,
     dump_file TEXT,
-    round_number INTEGER DEFAULT 1
+    round_number INTEGER
 );
 
 CREATE TABLE baseline_results (


### PR DESCRIPTION
## Summary
- improve `check_round_consistency.py` so it prints the SQL commands needed to fix mismatched investigations
- mention that behaviour in the README

## Testing
- `uv pip install -q -r requirements.txt`
- `uv pip install pytest`
- `uv run pytest -q`
- `PGUSER=root PGDATABASE=narrative uv run python check_round_consistency.py > /tmp/out && head -n 5 /tmp/out`

------
https://chatgpt.com/codex/tasks/task_e_685b6dc997808325ae62c20d436a04aa