### PR TITLE
Fix Titanic config splits_table reference

### DIFF
--- a/configs/titanic_medical.config.json
+++ b/configs/titanic_medical.config.json
@@ -2,7 +2,7 @@
   "table_name": "patients",
   "primary_key": "Patient_ID",
   "target_field": "Outcome",
-  "splits_table": "patient_splits",
+  "splits_table": "patient_split_ids",
   "rounds_table": "titanic_rounds",
   "columns": [
     "Outcome",


### PR DESCRIPTION
## Summary
- fix Titanic config so rounds table references `patient_split_ids`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfbe6e9688325b1c90fd7f9da2074