### PR TITLE
Fix duplicate script header output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,14 @@ jobs:
           PGDATABASE: narrative
         run: |
           uv run python -m unittest discover -v
+      - name: Check duplicate investigations
+        env:
+          PGHOST: localhost
+          PGUSER: root
+          PGDATABASE: narrative
+        run: |
+          output=$(uv run find_duplicate_investigations.py)
+          if [ -n "$output" ]; then
+            echo "$output"
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Restore database
+        env:
+          PGHOST: localhost
+          PGUSER: root
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+          curl -L https://datadumps.ifost.org.au/narrative-learning/narrative.sql.gz -o narrative.sql.gz
+          gunzip -c narrative.sql.gz | psql -d narrative
       - name: Run tests
         env:
           PGHOST: localhost

--- a/find_duplicate_investigations.py
+++ b/find_duplicate_investigations.py
@@ -45,13 +45,22 @@ def main() -> None:
             cfg = json.load(f)
         dataset_round_tables[dataset] = cfg.get("rounds_table", f"{dataset}_rounds")
 
-    if not args.delete_sql:
-        print(
-            "dataset|model|sqlite_database|round_tracking_file|dump_file|round_number|ids|ids_with_data"
-        )
-    for key, ids in sorted(groups.items(), key=lambda kv: kv[0]):
+    header_printed = False
+    def sort_key(item: tuple[tuple, list[int]]) -> tuple:
+        key = item[0]
+        # Sort elements safely even if they have mixed types or None
+        # by converting each part of the key to a string. None becomes
+        # an empty string so that keys remain comparable.
+        return tuple("" if part is None else str(part) for part in key)
+
+    for key, ids in sorted(groups.items(), key=sort_key):
         if len(ids) <= 1:
             continue
+        if not args.delete_sql and not header_printed:
+            print(
+                "dataset|model|sqlite_database|round_tracking_file|dump_file|round_number|ids|ids_with_data"
+            )
+            header_printed = True
         dataset, model, db, round_file, dump_file, round_no = key
         round_table = dataset_round_tables.get(dataset, f"{dataset}_rounds")
         ids_with_data: list[int] = []


### PR DESCRIPTION
## Summary
- hide duplicate report header when there are no duplicates
- fail CI if find_duplicate_investigations.py outputs anything

## Testing
- `PGUSER=root PGDATABASE=narrative uv run python -m unittest discover -v`
- `PGUSER=root PGDATABASE=narrative uv run find_duplicate_investigations.py`

------
https://chatgpt.com/codex/tasks/task_e_685d539e225883259455685296abbb28