### PR TITLE
Add round completion metrics

### DIFF
--- a/initialise_database.py
+++ b/initialise_database.py
@@ -140,7 +140,11 @@ def generate_schema_sql(
     schema_sql += f"  split_id integer references {splits_table}(split_id),\n"
     schema_sql += "  prompt text,\n"
     schema_sql += "  reasoning_for_this_prompt text,\n"
-    schema_sql += "  stderr_from_prompt_creation text\n"
+    schema_sql += "  stderr_from_prompt_creation text,\n"
+    schema_sql += "  train_accuracy real,\n"
+    schema_sql += "  validation_accuracy real,\n"
+    schema_sql += "  test_accuracy real,\n"
+    schema_sql += "  round_completed timestamp\n"
     schema_sql += ");\n\n"
 
     # Add inferences table with name based on the rounds table

--- a/investigate.py
+++ b/investigate.py
@@ -17,6 +17,9 @@ import sys
 import tempfile
 import json
 
+import datasetconfig
+from modules.round_utils import update_round_statistics
+
 from modules.postgres import get_connection
 
 
@@ -89,6 +92,7 @@ def main() -> None:
         config_json = json.load(f)
     rounds_table = config_json.get("rounds_table", f"{dataset}_rounds")
     splits_table = config_json.get("splits_table", f"{dataset}_splits")
+    config_obj = datasetconfig.DatasetConfig(conn, config, dataset, args.investigation_id)
 
     env = {
         "NARRATIVE_LEARNING_CONFIG": config,
@@ -160,6 +164,8 @@ def main() -> None:
             != 0
         ):
             sys.exit(1)
+
+        update_round_statistics(config_obj, round_no)
 
         with tempfile.NamedTemporaryFile() as tmp:
             if (

--- a/modules/round_utils.py
+++ b/modules/round_utils.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Helper for updating round statistics."""
+from __future__ import annotations
+
+from datasetconfig import DatasetConfig
+
+
+def update_round_statistics(config: DatasetConfig, round_id: int) -> None:
+    """Update completion time and accuracies for a round."""
+
+    conn = config.conn
+    cur = conn.cursor()
+    inf_table = f"{config.dataset}_inferences" if config.dataset else "inferences"
+
+    params = [round_id]
+    query = f"SELECT count(*) FROM {inf_table} WHERE round_id = ?"
+    if config.investigation_id is not None:
+        query += " AND investigation_id = ?"
+        params.append(config.investigation_id)
+    config._execute(cur, query, tuple(params))
+    inf_count = cur.fetchone()[0]
+
+    total = config.get_data_point_count()
+
+    rounds_table = config.rounds_table
+
+    if inf_count == total:
+        params = [round_id]
+        query = f"SELECT max(creation_time) FROM {inf_table} WHERE round_id = ?"
+        if config.investigation_id is not None:
+            query += " AND investigation_id = ?"
+            params.append(config.investigation_id)
+        config._execute(cur, query, tuple(params))
+        round_completed = cur.fetchone()[0]
+
+        train_matrix = config.get_confusion_matrix(round_id)
+        val_matrix = config.get_confusion_matrix(round_id, on_holdout_data=True)
+        test_matrix = config.get_confusion_matrix(
+            round_id, on_holdout_data=True, on_test_data=True
+        )
+
+        train_accuracy = config.calculate_metric(train_matrix, "accuracy")
+        validation_accuracy = config.calculate_metric(val_matrix, "accuracy")
+        test_accuracy = config.calculate_metric(test_matrix, "accuracy")
+    else:
+        round_completed = None
+        train_accuracy = None
+        validation_accuracy = None
+        test_accuracy = None
+
+    update_query = (
+        f"UPDATE {rounds_table} "
+        "SET round_completed = ?, "
+        "train_accuracy = ?, "
+        "validation_accuracy = ?, "
+        "test_accuracy = ? "
+        "WHERE round_id = ?"
+    )
+    config._execute(
+        cur,
+        update_query,
+        (
+            round_completed,
+            train_accuracy,
+            validation_accuracy,
+            test_accuracy,
+            round_id,
+        ),
+    )
+    conn.commit()
+

--- a/postgres-schemas/espionage_schema.sql
+++ b/postgres-schemas/espionage_schema.sql
@@ -24,6 +24,10 @@ CREATE TABLE IF NOT EXISTS espionage_rounds (
     prompt TEXT,
     reasoning_for_this_prompt TEXT,
     stderr_from_prompt_creation TEXT,
+    train_accuracy DOUBLE PRECISION,
+    validation_accuracy DOUBLE PRECISION,
+    test_accuracy DOUBLE PRECISION,
+    round_completed TIMESTAMP,
     investigation_id INTEGER REFERENCES investigations(id)
 );
 

--- a/postgres-schemas/potions_schema.sql
+++ b/postgres-schemas/potions_schema.sql
@@ -24,6 +24,10 @@ CREATE TABLE IF NOT EXISTS potions_rounds (
     prompt TEXT,
     reasoning_for_this_prompt TEXT,
     stderr_from_prompt_creation TEXT,
+    train_accuracy DOUBLE PRECISION,
+    validation_accuracy DOUBLE PRECISION,
+    test_accuracy DOUBLE PRECISION,
+    round_completed TIMESTAMP,
     investigation_id INTEGER REFERENCES investigations(id)
 );
 

--- a/postgres-schemas/southgermancredit_schema.sql
+++ b/postgres-schemas/southgermancredit_schema.sql
@@ -43,6 +43,10 @@ CREATE TABLE IF NOT EXISTS southgermancredit_rounds (
     prompt TEXT,
     reasoning_for_this_prompt TEXT,
     stderr_from_prompt_creation TEXT,
+    train_accuracy DOUBLE PRECISION,
+    validation_accuracy DOUBLE PRECISION,
+    test_accuracy DOUBLE PRECISION,
+    round_completed TIMESTAMP,
     investigation_id INTEGER REFERENCES investigations(id)
 );
 

--- a/postgres-schemas/timetravel_insurance_schema.sql
+++ b/postgres-schemas/timetravel_insurance_schema.sql
@@ -24,6 +24,10 @@ CREATE TABLE IF NOT EXISTS timetravel_insurance_rounds (
     prompt TEXT,
     reasoning_for_this_prompt TEXT,
     stderr_from_prompt_creation TEXT,
+    train_accuracy DOUBLE PRECISION,
+    validation_accuracy DOUBLE PRECISION,
+    test_accuracy DOUBLE PRECISION,
+    round_completed TIMESTAMP,
     investigation_id INTEGER REFERENCES investigations(id)
 );
 

--- a/postgres-schemas/titanic_schema.sql
+++ b/postgres-schemas/titanic_schema.sql
@@ -30,6 +30,10 @@ CREATE TABLE IF NOT EXISTS titanic_rounds (
     prompt TEXT,
     reasoning_for_this_prompt TEXT,
     stderr_from_prompt_creation TEXT,
+    train_accuracy DOUBLE PRECISION,
+    validation_accuracy DOUBLE PRECISION,
+    test_accuracy DOUBLE PRECISION,
+    round_completed TIMESTAMP,
     investigation_id INTEGER REFERENCES investigations(id)
 );
 

--- a/postgres-schemas/wisconsin_schema.sql
+++ b/postgres-schemas/wisconsin_schema.sql
@@ -53,6 +53,10 @@ CREATE TABLE IF NOT EXISTS wisconsin_rounds (
     prompt TEXT,
     reasoning_for_this_prompt TEXT,
     stderr_from_prompt_creation TEXT,
+    train_accuracy DOUBLE PRECISION,
+    validation_accuracy DOUBLE PRECISION,
+    test_accuracy DOUBLE PRECISION,
+    round_completed TIMESTAMP,
     investigation_id INTEGER REFERENCES investigations(id)
 );
 

--- a/schema.sql
+++ b/schema.sql
@@ -40,6 +40,10 @@ create table if not exists rounds (
   split_id integer references splits(split_id),
   prompt text,
   reasoning_for_this_prompt text,
-  stderr_from_prompt_creation text
+  stderr_from_prompt_creation text,
+  train_accuracy real,
+  validation_accuracy real,
+  test_accuracy real,
+  round_completed datetime
 );
 

--- a/update_round_stats.py
+++ b/update_round_stats.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Update accuracy metrics and completion time for a round."""
+import argparse
+import os
+
+import datasetconfig
+from modules.postgres import get_connection, get_investigation_settings
+from modules.round_utils import update_round_statistics
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update round statistics")
+    parser.add_argument("round_id", type=int, help="Round ID to update")
+    parser.add_argument("--dataset", help="Dataset name")
+    parser.add_argument("--config", help="Dataset config file")
+    parser.add_argument("--investigation-id", type=int, help="Investigation ID")
+    parser.add_argument("--dsn", help="PostgreSQL DSN")
+    parser.add_argument("--pg-config", help="JSON file containing postgres_dsn")
+    args = parser.parse_args()
+
+    if args.investigation_id is not None:
+        conn = get_connection(args.dsn, args.pg_config)
+        ds, cfg = get_investigation_settings(conn, args.investigation_id)
+        dataset = args.dataset or ds
+        config_file = args.config or cfg
+    else:
+        if not args.dataset or not args.config:
+            parser.error("--dataset and --config are required without --investigation-id")
+        conn = get_connection(args.dsn, args.pg_config)
+        dataset = args.dataset
+        config_file = args.config
+
+    config_obj = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
+    update_round_statistics(config_obj, args.round_id)
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/update_rounds.sql
+++ b/update_rounds.sql
@@ -1,0 +1,23 @@
+-- Add accuracy columns and round_completed timestamp for all *_rounds tables
+--
+-- This repository defines only six *_rounds tables:
+--   espionage_rounds, potions_rounds, southgermancredit_rounds,
+--   timetravel_insurance_rounds, titanic_rounds and wisconsin_rounds.
+-- The loop below updates each of them if present, without affecting any other
+-- tables.
+DO $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN SELECT table_schema, table_name
+             FROM information_schema.tables
+             WHERE table_schema NOT IN ('pg_catalog','information_schema')
+               AND table_name LIKE '%_rounds'
+    LOOP
+        EXECUTE format('ALTER TABLE %I.%I ADD COLUMN IF NOT EXISTS train_accuracy DOUBLE PRECISION;', r.table_schema, r.table_name);
+        EXECUTE format('ALTER TABLE %I.%I ADD COLUMN IF NOT EXISTS validation_accuracy DOUBLE PRECISION;', r.table_schema, r.table_name);
+        EXECUTE format('ALTER TABLE %I.%I ADD COLUMN IF NOT EXISTS test_accuracy DOUBLE PRECISION;', r.table_schema, r.table_name);
+        EXECUTE format('ALTER TABLE %I.%I ADD COLUMN IF NOT EXISTS round_completed TIMESTAMP;', r.table_schema, r.table_name);
+    END LOOP;
+END $$;
+


### PR DESCRIPTION
## Summary
- track new fields on all `_rounds` tables (train/validation/test accuracy and completion timestamp)
- generate these columns in newly initialised databases
- provide SQL patch to retrofit existing tables
- add script and module for populating round stats
- update investigate.py to record statistics after each round
- clarify update script with comment about the six tables

## Testing
- `pytest -q`
- `psql -U root -d narrative -f update_rounds.sql`
- `uv run python update_round_stats.py 1 --dataset espionage --config configs/espionage.config.json --dsn "dbname=narrative"`
- `uv run python update_round_stats.py 1 --dataset potions --config configs/potions.config.json --dsn "dbname=narrative"`
- `uv run python update_round_stats.py 1 --dataset southgermancredit --config configs/sgc_coral.config.json --dsn "dbname=narrative"`
- `uv run python update_round_stats.py 1 --dataset timetravel_insurance --config configs/timetravel_insurance.config.json --dsn "dbname=narrative"`
- `uv run python update_round_stats.py 1 --dataset titanic --config configs/titanic_medical.config.json --dsn "dbname=narrative"`
- `uv run python update_round_stats.py 1 --dataset wisconsin --config configs/wisconsin_exoplanets.config.json --dsn "dbname=narrative"`


------
https://chatgpt.com/codex/tasks/task_e_685dfd66095483259854de1e753b5acc