### PR TITLE
Simplify round stat updater

### DIFF
--- a/round_investigations_view.sql
+++ b/round_investigations_view.sql
@@ -1,0 +1,18 @@
+-- View mapping round IDs to their investigation ID
+-- Each *_rounds table stores the investigation that produced a round.
+-- This view unions all of them so scripts can look up an investigation
+-- given only a round_id.
+
+CREATE OR REPLACE VIEW round_investigations AS
+    SELECT round_id, investigation_id FROM espionage_rounds
+  UNION ALL
+    SELECT round_id, investigation_id FROM potions_rounds
+  UNION ALL
+    SELECT round_id, investigation_id FROM southgermancredit_rounds
+  UNION ALL
+    SELECT round_id, investigation_id FROM timetravel_insurance_rounds
+  UNION ALL
+    SELECT round_id, investigation_id FROM titanic_rounds
+  UNION ALL
+    SELECT round_id, investigation_id FROM wisconsin_rounds;
+

--- a/update_round_stats.py
+++ b/update_round_stats.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Update accuracy metrics and completion time for a round."""
 import argparse
-import os
 
 import datasetconfig
 from modules.postgres import get_connection, get_investigation_settings
@@ -11,26 +10,25 @@ from modules.round_utils import update_round_statistics
 def main() -> None:
     parser = argparse.ArgumentParser(description="Update round statistics")
     parser.add_argument("round_id", type=int, help="Round ID to update")
-    parser.add_argument("--dataset", help="Dataset name")
-    parser.add_argument("--config", help="Dataset config file")
-    parser.add_argument("--investigation-id", type=int, help="Investigation ID")
-    parser.add_argument("--dsn", help="PostgreSQL DSN")
-    parser.add_argument("--pg-config", help="JSON file containing postgres_dsn")
     args = parser.parse_args()
 
-    if args.investigation_id is not None:
-        conn = get_connection(args.dsn, args.pg_config)
-        ds, cfg = get_investigation_settings(conn, args.investigation_id)
-        dataset = args.dataset or ds
-        config_file = args.config or cfg
-    else:
-        if not args.dataset or not args.config:
-            parser.error("--dataset and --config are required without --investigation-id")
-        conn = get_connection(args.dsn, args.pg_config)
-        dataset = args.dataset
-        config_file = args.config
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT investigation_id FROM round_investigations WHERE round_id = %s",
+        (args.round_id,),
+    )
+    rows = cur.fetchall()
+    if not rows:
+        raise SystemExit(f"round {args.round_id} not found")
+    if len(rows) > 1:
+        raise SystemExit(f"round {args.round_id} maps to multiple investigations")
+    investigation_id = rows[0][0]
 
-    config_obj = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
+    dataset, config_file = get_investigation_settings(conn, investigation_id)
+    config_obj = datasetconfig.DatasetConfig(
+        conn, config_file, dataset, investigation_id
+    )
     update_round_statistics(config_obj, args.round_id)
     conn.close()
 


### PR DESCRIPTION
## Summary
- add a view that maps round IDs to investigations
- simplify `update_round_stats.py` to take only a round_id and derive the dataset and config

## Testing
- `python3 -m py_compile update_round_stats.py`
- `PGUSER=root pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8ff48a308325b9e1482ed1b7d012