### PR TITLE
Fix empty investigation detection

### DIFF
--- a/create_task_csv_file.py
+++ b/create_task_csv_file.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import csv
 import sys
-import sqlite3
 import math
 import sys
 import re
@@ -13,6 +12,7 @@ from typing import Dict, List, Optional, Tuple
 import datasetconfig
 from statsmodels.stats.proportion import proportion_confint
 from env_settings import EnvSettings
+from modules.postgres import get_connection
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Create CSV file from env files')
@@ -40,9 +40,10 @@ def get_model_data(env_file_path: str, task: str, model_details: Dict) -> Option
         sys.stderr.write(f"Skipping {env_file_path} - {error_message}\n")
         return None
 
-    # Connect to database
-    conn = sqlite3.connect(f"file:{settings.database}?mode=ro", uri=True)
-    config = datasetconfig.DatasetConfig(conn, settings.config)
+    # Connect to PostgreSQL using libpq environment defaults
+    conn = get_connection()
+    dataset = os.path.basename(os.path.dirname(env_file_path))
+    config = datasetconfig.DatasetConfig(conn, settings.config, dataset)
 
     # Get the latest split ID
     split_id = config.get_latest_split_id()

--- a/env_generator.py
+++ b/env_generator.py
@@ -23,9 +23,6 @@ def generate_env_files(datasets, models, base_dir):
             # Determine example count (10 if model ends with '10', otherwise 3)
             example_count = "10" if model.endswith("10") else "3"
             
-            # Set model names according to pattern
-            database_path = f"results/{dataset}-{model}.sqlite"
-            
             # Use gpt-4o-mini for inference across all models
             inference_model = "gpt-4o-mini"
             
@@ -75,18 +72,13 @@ def generate_env_files(datasets, models, base_dir):
             # Get the training model from the mapping, with fallback to gpt-4o-mini
             training_model = model_mapping.get(model, "gpt-4o-mini")
             
-            # Round tracking file follows the pattern
-            round_tracking_file = f".round-tracking-file.{dataset}.{model}"
-            
-            # Dump file is similar to database but with different extension and directory
+            # Dump file is similar to the old database name but with a .sql extension
             dump_file = f"dumps/{dataset}-{model}.sql"
-            
+
             # Generate the content for the .env file
             env_content = f"""export NARRATIVE_LEARNING_CONFIG={config_file}
-export NARRATIVE_LEARNING_DATABASE={database_path}
 export NARRATIVE_LEARNING_TRAINING_MODEL={training_model}
 export NARRATIVE_LEARNING_INFERENCE_MODEL={inference_model}
-export ROUND_TRACKING_FILE={round_tracking_file}
 export NARRATIVE_LEARNING_EXAMPLE_COUNT={example_count}
 export NARRATIVE_LEARNING_DUMP={dump_file}
 """

--- a/env_settings.py
+++ b/env_settings.py
@@ -53,12 +53,8 @@ class EnvSettings:
             return cls()
     
     def is_valid(self) -> bool:
-        """Check if all required settings are present."""
-        return all(getattr(self, key) is not None for key in ['database', 'config', 'model'])
-    
-    def database_exists(self) -> bool:
-        """Check if the database file exists."""
-        return self.database is not None and os.path.exists(self.database)
+        """Check if required settings are present."""
+        return all(getattr(self, key) is not None for key in ['config', 'model'])
     
     def config_exists(self) -> bool:
         """Check if the config file exists."""
@@ -71,12 +67,9 @@ class EnvSettings:
             tuple: (is_valid, error_message)
         """
         if not self.is_valid():
-            missing = [key for key in ['database', 'config', 'model'] 
+            missing = [key for key in ['config', 'model']
                       if getattr(self, key) is None]
             return False, f"Missing required settings: {', '.join(missing)}"
-        
-        if not self.database_exists():
-            return False, f"Database file not found: {self.database}"
             
         if not self.config_exists():
             return False, f"Config file not found: {self.config}"

--- a/investigate.py
+++ b/investigate.py
@@ -57,12 +57,10 @@ def main() -> None:
         SELECT i.round_number,
                i.dataset,
                d.config_file,
-               i.sqlite_database,
                m.training_model,
                m.inference_model,
                m.example_count,
                m.patience,
-               i.round_tracking_file,
                i.dump_file
         FROM investigations i
         JOIN datasets d ON i.dataset = d.dataset
@@ -79,12 +77,10 @@ def main() -> None:
         round_no,
         dataset,
         config,
-        sqlite_db,
         training_model,
         inference_model,
         example_count,
         patience,
-        round_file,
         dump_path,
     ) = row
 
@@ -96,10 +92,8 @@ def main() -> None:
 
     env = {
         "NARRATIVE_LEARNING_CONFIG": config,
-        "NARRATIVE_LEARNING_DATABASE": sqlite_db,
         "NARRATIVE_LEARNING_TRAINING_MODEL": training_model,
         "NARRATIVE_LEARNING_INFERENCE_MODEL": inference_model,
-        "ROUND_TRACKING_FILE": round_file,
     }
     if example_count:
         env["NARRATIVE_LEARNING_EXAMPLE_COUNT"] = str(example_count)

--- a/investigation_info.py
+++ b/investigation_info.py
@@ -25,8 +25,6 @@ def main() -> None:
     cur.execute(
         """
         SELECT i.round_number,
-               i.sqlite_database,
-               i.round_tracking_file,
                d.dataset,
                d.config_file,
                m.model,
@@ -47,8 +45,6 @@ def main() -> None:
 
     (
         round_no,
-        sqlite_db,
-        round_file,
         dataset,
         config_file,
         model,
@@ -67,8 +63,6 @@ def main() -> None:
     print(f"  Example count: {example_count}")
     print(f"  Patience: {patience}")
     print(f"  Current round: {round_no}")
-    print(f"  SQLite DB: {sqlite_db}")
-    print(f"  Round tracking file: {round_file}")
 
     cfg = DatasetConfig(conn, config_file, dataset, args.investigation_id)
     try:

--- a/predict.py
+++ b/predict.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import sqlite3
 import sys
 import os
 import json
@@ -105,15 +104,12 @@ Entity Data:
 
 
 if __name__ == '__main__':
-    default_database = os.environ.get('NARRATIVE_LEARNING_DATABASE', None)
     default_model = os.environ.get('NARRATIVE_LEARNING_INFERENCE_MODEL', None)
     default_config = os.environ.get('NARRATIVE_LEARNING_CONFIG', None)
 
     parser = argparse.ArgumentParser(
         description="Make predictions for an entity based on the round prompt"
     )
-    parser.add_argument('--database', default=default_database,
-                        help="Path to the SQLite database file")
     parser.add_argument('--dsn', help='PostgreSQL DSN')
     parser.add_argument('--pg-config', help='JSON file containing postgres_dsn')
     parser.add_argument('--round-id', type=int, required=True,
@@ -134,14 +130,11 @@ if __name__ == '__main__':
         dataset, config_file = get_investigation_settings(conn, args.investigation_id)
         config = datasetconfig.DatasetConfig(conn, config_file, dataset, args.investigation_id)
     else:
-        if not (args.database or args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
-            sys.exit("Must specify --database or --dsn/--pg-config for PostgreSQL")
+        if not (args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN')):
+            sys.exit("Must specify --dsn/--pg-config for PostgreSQL")
         if args.config is None:
             sys.exit("Must specify --config or set the env variable NARRATIVE_LEARNING_CONFIG")
-        if args.dsn or args.pg_config or os.environ.get('POSTGRES_DSN'):
-            conn = get_connection(args.dsn, args.pg_config)
-        else:
-            conn = sqlite3.connect(args.database)
+        conn = get_connection(args.dsn, args.pg_config)
         config = datasetconfig.DatasetConfig(conn, args.config)
 
     predict(config, args.round_id, args.entity_id, args.model, args.dry_run, args.investigation_id)

--- a/test_env_settings.py
+++ b/test_env_settings.py
@@ -9,7 +9,6 @@ class TestEnvSettings(unittest.TestCase):
     def test_from_file(self):
         # Create a temporary env file
         content = """
-        NARRATIVE_LEARNING_DATABASE=/path/to/db.sqlite
         NARRATIVE_LEARNING_CONFIG=/path/to/config.json
         NARRATIVE_LEARNING_TRAINING_MODEL=gpt-4o
         NARRATIVE_LEARNING_EXAMPLE_COUNT=10
@@ -24,7 +23,6 @@ class TestEnvSettings(unittest.TestCase):
             settings = EnvSettings.from_file(temp_path)
             
             # Check values
-            self.assertEqual(settings.database, '/path/to/db.sqlite')
             self.assertEqual(settings.config, '/path/to/config.json')
             self.assertEqual(settings.model, 'gpt-4o')
             self.assertEqual(settings.sampler, 10)
@@ -42,14 +40,13 @@ class TestEnvSettings(unittest.TestCase):
         # Test with empty settings
         settings = EnvSettings()
         self.assertFalse(settings.is_valid())
-        
+
         # Test with partial settings
-        settings = EnvSettings(database='/path/to/db.sqlite')
+        settings = EnvSettings(config='/path/to/config.json')
         self.assertFalse(settings.is_valid())
-        
+
         # Test with complete settings
         settings = EnvSettings(
-            database='/path/to/db.sqlite',
             config='/path/to/config.json',
             model='gpt-4o'
         )


### PR DESCRIPTION
## Summary
- ensure `list_empty_investigations.py` checks PostgreSQL only
- drop SQLite and round-tracking file support across scripts
- adjust helper utilities and env generator
- update tests

## Testing
- `PGUSER=root python3 test_env_settings.py`
- `PGUSER=root python3 test_postgres.py`


------
https://chatgpt.com/codex/tasks/task_e_685f6038ed208325b6112bb3790d9b10