### PR TITLE
Fix round import collisions

### DIFF
--- a/POSTGRESQL_MIGRATION.md
+++ b/POSTGRESQL_MIGRATION.md
@@ -18,6 +18,9 @@ Migration utilities:
   `postgres-schemas/`. Dataset-specific tables (the core data and split
   assignments) are checked for consistency across all SQLite files. Only the
   `rounds` and `inferences` tables receive an extra `investigation_id` column
-  when imported.
+  when imported. Because each SQLite database numbers rounds starting from 1,
+  the import script lets PostgreSQL assign new ``round_id`` values and updates
+  the corresponding ``inferences`` rows so that duplicates do not cause
+  conflicts.
 
 


### PR DESCRIPTION
## Summary
- preserve dataset and split import logic
- insert rounds one by one so PostgreSQL assigns new IDs
- remap inferences to those new round IDs
- document the renumbering behaviour in the migration guide

## Testing
- `uv run python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6863e5373fcc83259f59900ffbb31199