### PR TITLE
Add cleanup for duplicate rounds

### DIFF
--- a/check_round_time_span.py
+++ b/check_round_time_span.py
@@ -1,0 +1,56 @@
+import json
+from modules.postgres import get_connection
+
+SPAN_LIMIT = '28 days'
+
+
+def main():
+    conn = get_connection()
+    cur = conn.cursor()
+
+    cur.execute("SELECT dataset, config_file FROM datasets")
+    datasets = cur.fetchall()
+
+    issues = []
+    earliest_dates = []
+
+    for dataset, cfg_path in datasets:
+        with open(cfg_path, 'r', encoding='utf-8') as f:
+            cfg = json.load(f)
+        table = cfg.get('rounds_table', f"{dataset}_rounds")
+
+        cur.execute(f"SELECT MIN(round_start) FROM {table}")
+        earliest = cur.fetchone()[0]
+        earliest_dates.append(earliest)
+
+        cur.execute(
+            f"""
+            SELECT investigation_id, MIN(round_start) AS first_round,
+                   MAX(round_start) AS last_round,
+                   MAX(round_start) - MIN(round_start) AS span,
+                   COUNT(*) AS round_count
+              FROM {table}
+             GROUP BY investigation_id
+            HAVING COUNT(*) > 1 AND MAX(round_start) - MIN(round_start) > INTERVAL '{SPAN_LIMIT}'
+             ORDER BY span DESC
+            """
+        )
+        rows = cur.fetchall()
+        if rows:
+            issues.append((dataset, rows))
+
+    print('Earliest round_start in any dataset:', min(earliest_dates))
+    if not issues:
+        print('No investigations have rounds more than', SPAN_LIMIT, 'apart.')
+    else:
+        for dataset, rows in issues:
+            print(f"Dataset {dataset} investigations with rounds spaced over {SPAN_LIMIT}:")
+            for inv_id, first, last, span, count in rows:
+                print(f"  investigation {inv_id}: {count} rounds from {first} to {last} span {span}")
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/delete_duplicate_rounds.sql
+++ b/delete_duplicate_rounds.sql
@@ -1,0 +1,27 @@
+-- Delete duplicate rounds for each investigation across all *_rounds tables.
+-- For investigations with multiple rounds, keep only the earliest round_id.
+DO $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN
+        SELECT table_schema, table_name
+          FROM information_schema.tables
+         WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+           AND table_name LIKE '%_rounds'
+    LOOP
+        EXECUTE format(
+            $$DELETE FROM %I.%I t
+              USING (
+                  SELECT investigation_id, MIN(round_id) AS keep_id
+                    FROM %I.%I
+                   GROUP BY investigation_id
+                   HAVING COUNT(*) > 1
+              ) k
+             WHERE t.investigation_id = k.investigation_id
+               AND t.round_id <> k.keep_id;$$,
+            r.table_schema, r.table_name,
+            r.table_schema, r.table_name
+        );
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Summary
- adjust `check_round_time_span.py` to use a 28‑day window
- add `delete_duplicate_rounds.sql` to remove later rounds when an investigation already has one

## Testing
- `PGUSER=root PGDATABASE=narrative uv run python3 check_round_time_span.py | head -n 20`
- `PGUSER=root PGDATABASE=narrative uv run python3 check_round_time_span.py | tail -n 20`
- `head -n 5 delete_duplicate_rounds.sql`
- `tail -n 5 delete_duplicate_rounds.sql`


------
https://chatgpt.com/codex/tasks/task_e_68665df95d8c8325a27e9756eb51f566