### PR TITLE
Update delete_round utility

### DIFF
--- a/delete_round.py
+++ b/delete_round.py
@@ -18,63 +18,122 @@ def fetch_all_dict(cur) -> list[dict[str, Any]]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Delete a round after exporting")
-    parser.add_argument("round_uuid", help="Round UUID to remove")
+    parser.add_argument(
+        "round_uuid",
+        nargs="*",
+        help="Round UUID(s) to remove",
+    )
+    parser.add_argument("--investigation-id", type=int, help="Investigation ID")
+    parser.add_argument(
+        "--round-id",
+        type=int,
+        nargs="+",
+        help="Round ID(s) within investigation",
+    )
     parser.add_argument("--output", help="File to write round data")
     parser.add_argument("--dsn", help="PostgreSQL DSN")
     parser.add_argument("--config", help="PostgreSQL config JSON")
     args = parser.parse_args()
 
+    if args.round_uuid:
+        if args.investigation_id or args.round_id:
+            parser.error(
+                "Use round UUID(s) or both --investigation-id and --round-id"
+            )
+    elif args.round_id:
+        if args.investigation_id is None:
+            parser.error("--round-id requires --investigation-id")
+    else:
+        parser.error(
+            "Specify round UUID(s) or both --investigation-id and --round-id"
+        )
+
     conn = get_connection(args.dsn, args.config)
     conn.autocommit = True
     cur = conn.cursor()
 
-    cur.execute(
-        "SELECT investigation_id FROM round_investigations WHERE round_uuid = %s",
-        (args.round_uuid,),
-    )
-    rows = cur.fetchall()
-    if not rows:
-        raise SystemExit(f"round {args.round_uuid} not found")
-    if len(rows) > 1:
-        raise SystemExit(f"round {args.round_uuid} maps to multiple investigations")
-    investigation_id = rows[0][0]
+    export_data = []
 
-    dataset, cfg_path = get_investigation_settings(conn, investigation_id)
-    cfg = DatasetConfig(conn, cfg_path, dataset, investigation_id)
+    if args.round_uuid:
+        for uuid in args.round_uuid:
+            cur.execute(
+                "SELECT investigation_id FROM round_investigations WHERE round_uuid = %s",
+                (uuid,),
+            )
+            rows = cur.fetchall()
+            if not rows:
+                raise SystemExit(f"round {uuid} not found")
+            if len(rows) > 1:
+                raise SystemExit(f"round {uuid} maps to multiple investigations")
+            investigation_id = rows[0][0]
+            dataset, cfg_path = get_investigation_settings(conn, investigation_id)
+            cfg = DatasetConfig(conn, cfg_path, dataset, investigation_id)
+            cur.execute(
+                f"SELECT round_id FROM {cfg.rounds_table} WHERE round_uuid = %s",
+                (uuid,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise SystemExit(f"uuid {uuid} not found in {cfg.rounds_table}")
+            round_id = row[0]
 
-    cur.execute(
-        f"SELECT round_id FROM {cfg.rounds_table} WHERE round_uuid = %s",
-        (args.round_uuid,),
-    )
-    round_row = cur.fetchone()
-    if round_row is None:
-        raise SystemExit(f"uuid {args.round_uuid} not found in {cfg.rounds_table}")
-    round_id = round_row[0]
+            cur.execute(
+                f"SELECT * FROM {cfg.rounds_table} WHERE round_id = %s",
+                (round_id,),
+            )
+            round_data = fetch_all_dict(cur)[0]
 
-    cur.execute(
-        f"SELECT * FROM {cfg.rounds_table} WHERE round_id = %s",
-        (round_id,),
-    )
-    round_data = fetch_all_dict(cur)[0]
+            inf_table = f"{dataset}_inferences" if dataset else "inferences"
+            cur.execute(
+                f"SELECT * FROM {inf_table} WHERE round_id = %s",
+                (round_id,),
+            )
+            inferences = fetch_all_dict(cur)
 
-    inf_table = f"{dataset}_inferences" if dataset else "inferences"
-    cur.execute(
-        f"SELECT * FROM {inf_table} WHERE round_id = %s",
-        (round_id,),
-    )
-    inferences = fetch_all_dict(cur)
+            export_data.append({"round": round_data, "inferences": inferences})
 
-    if args.output:
-      with open(args.output, "w", encoding="utf-8") as f:
-        json.dump({"round": round_data, "inferences": inferences}, f, indent=2, default=str)
+            cur.execute(f"DELETE FROM {inf_table} WHERE round_id = %s", (round_id,))
+            cur.execute(f"DELETE FROM {cfg.rounds_table} WHERE round_id = %s", (round_id,))
 
-    cur.execute(f"DELETE FROM {inf_table} WHERE round_id = %s", (round_id,))
-    cur.execute(f"DELETE FROM {cfg.rounds_table} WHERE round_id = %s", (round_id,))
-
-    if args.output:
-       print(f"Round {round_id} exported to {args.output} and deleted")
+            print(f"Round {round_id} deleted")
     else:
-       print(f"Round {round_id} deleted")
+        dataset, cfg_path = get_investigation_settings(conn, args.investigation_id)
+        cfg = DatasetConfig(conn, cfg_path, dataset, args.investigation_id)
+        for rid in args.round_id:
+            cur.execute(
+                f"SELECT round_uuid FROM {cfg.rounds_table} WHERE round_id = %s AND investigation_id = %s",
+                (rid, args.investigation_id),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise SystemExit(
+                    f"round {rid} not found for investigation {args.investigation_id}"
+                )
+
+            cur.execute(
+                f"SELECT * FROM {cfg.rounds_table} WHERE round_id = %s",
+                (rid,),
+            )
+            round_data = fetch_all_dict(cur)[0]
+
+            inf_table = f"{dataset}_inferences" if dataset else "inferences"
+            cur.execute(
+                f"SELECT * FROM {inf_table} WHERE round_id = %s",
+                (rid,),
+            )
+            inferences = fetch_all_dict(cur)
+
+            export_data.append({"round": round_data, "inferences": inferences})
+
+            cur.execute(f"DELETE FROM {inf_table} WHERE round_id = %s", (rid,))
+            cur.execute(f"DELETE FROM {cfg.rounds_table} WHERE round_id = %s", (rid,))
+
+            print(f"Round {rid} deleted")
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(export_data[0] if len(export_data) == 1 else export_data, f, indent=2, default=str)
+        print(f"Exported {len(export_data)} round{'s' if len(export_data) != 1 else ''} to {args.output}")
 
     cur.close()
     conn.close()


### PR DESCRIPTION
## Summary
- allow deleting rounds by ID instead of UUID
- support deleting multiple UUIDs or round IDs

## Testing
- `uv pip install pytest`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1a85e4288325a8c55a0fe7417805