### PR TITLE
Add static website export utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,14 @@ Run it with libpq environment variables set, for example:
 ```bash
 PGUSER=root PGDATABASE=narrative ./check_round_consistency.py
 ```
+
+## Website export
+
+Run `./export_website.py` to generate static HTML pages in the `website/` directory. You can publish the site with:
+
+```bash
+rsync -av website/ merah.cassia.ifost.org.au:/var/www/vhosts/narrative-learning.symmachus.org/htdocs/
+```
+
+which will make it appear at <http://narrative-learning.symmachus.org/>.
+


### PR DESCRIPTION
## Summary
- provide `export_website.py` to create HTML pages for datasets, investigations, rounds and models
- document rsync deployment instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fca2b87148325ba3a382970c410a3