### PR TITLE
Allow baseline to load config from DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ After the tables are created, calculate baseline metrics with:
 PGUSER=root uv run baseline.py --dataset <dataset>
 ```
 
+`baseline.py` will look up the configuration path for the given dataset from
+the `datasets` table if `--config` is not supplied.
+
 Run this once per dataset to fill the `baseline_results` table.
 
 Then copy everything from `outputs/*_results.csv`

--- a/baseline.py
+++ b/baseline.py
@@ -247,10 +247,17 @@ def main():
         conn = get_connection(args.dsn, args.pg_config)
         if not args.dataset:
             sys.exit("Must specify --dataset")
-        if not args.config:
-            sys.exit("Must specify --config")
         dataset = args.dataset
-        config = DatasetConfig(conn, args.config, dataset)
+        if args.config:
+            config_path = args.config
+        else:
+            cur = conn.cursor()
+            cur.execute('SELECT config_file FROM datasets WHERE dataset = %s', (dataset,))
+            row = cur.fetchone()
+            if row is None:
+                sys.exit(f"Dataset {dataset} not found")
+            config_path = row[0]
+        config = DatasetConfig(conn, config_path, dataset)
     # Load and preprocess data
     train_df, test_df = load_data(conn, config)
 


### PR DESCRIPTION
## Summary
- `baseline.py` can now look up the dataset configuration file from the `datasets` table if `--config` is not provided
- document this automatic lookup in README

## Testing
- `PGUSER=root uv run python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68711491f5048325948bd47096ec4d94