### PR TITLE
Fix SQL placeholders for PostgreSQL

### DIFF
--- a/results_ensembling.py
+++ b/results_ensembling.py
@@ -35,8 +35,8 @@ def get_predictions_for_round(config, round_id, validation=False, use_decodex=Tr
             FROM inferences i
             JOIN {config.table_name} m ON i.{config.primary_key} = m.{config.primary_key}
             JOIN {config.splits_table} s ON (s.{config.primary_key} = i.{config.primary_key})
-            WHERE i.round_id = ?
-            AND s.split_id = ?
+            WHERE i.round_id = %s
+            AND s.split_id = %s
             AND s.validation = 1
         """
     else:
@@ -45,8 +45,8 @@ def get_predictions_for_round(config, round_id, validation=False, use_decodex=Tr
             FROM inferences i
             JOIN {config.table_name} m ON i.{config.primary_key} = m.{config.primary_key}
             JOIN {config.splits_table} s ON (s.{config.primary_key} = i.{config.primary_key})
-            WHERE i.round_id = ?
-            AND s.split_id = ?
+            WHERE i.round_id = %s
+            AND s.split_id = %s
             AND s.holdout = 1
             AND s.validation = 0
         """


### PR DESCRIPTION
## Summary
- fix SQL placeholders in `results_ensembling.py` to use `%s` with psycopg2

## Testing
- `PGUSER=root uv run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687188afdda88325980ad75ace753c67