### PR TITLE
Fix website deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,11 @@ jobs:
           sudo apt-get install -y postgresql postgresql-client rsync python3-psycopg2
           curl -LsSf https://astral.sh/uv/install.sh | sh
           ./envsetup.sh
+          sudo -u postgres createuser --superuser $(whoami)
       - name: Build website
         run: |
-          sudo -u postgres -E .venv/bin/python export_website.py
+          export PGUSER=$(whoami)
+          uv run export_website.py
       - name: Deploy
         env:
           SSH_KEY: ${{ secrets.DEPLOYMENT_SSH_KEY }}


### PR DESCRIPTION
## Summary
- create a PostgreSQL role for the workflow user
- run `export_website.py` as the workflow user using `uv`

## Testing
- `PGUSER=root pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871baa9baa4832595469e57bad7521a