### PR TITLE
Fix plotting for export_website

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -44,7 +44,9 @@ def plot_release_chart(conn, dataset: str, csv_path: str, out_path: str) -> None
     )
     info = pd.DataFrame(cur.fetchall(), columns=["Model", "Release Date", "ollama"])
     df = df.merge(info, on="Model", how="left")
-    df = df[~df["ollama"]]
+    # ``ollama`` is True for models hosted on Ollama. These rows should be
+    # excluded from the plot, treating missing values as False.
+    df = df[~df["ollama"].fillna(False).astype(bool)]
     df.dropna(subset=["Release Date", "Neg Log Error"], inplace=True)
     if df.empty:
         return


### PR DESCRIPTION
## Summary
- filter results by `ollama` correctly when building release charts

## Testing
- `PGUSER=root PGDATABASE=narrative uv run python export_website.py`
- `PGUSER=root PGDATABASE=narrative uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c4a6781c8325b1256c8838acd07a