### PR TITLE
Fix lexicostatistics ensemble handling

### DIFF
--- a/postgres-schemas/lexicostatistics_schema.sql
+++ b/postgres-schemas/lexicostatistics_schema.sql
@@ -1,6 +1,6 @@
 -- Schema for aggregated lexical statistics per language model
 CREATE TABLE IF NOT EXISTS lexicostatistics (
-    training_model TEXT PRIMARY KEY REFERENCES language_models(training_model),
+    training_model TEXT PRIMARY KEY,
     prompt_zipf DOUBLE PRECISION,
     prompt_zipf_r2 DOUBLE PRECISION,
     prompt_herdan DOUBLE PRECISION,


### PR DESCRIPTION
## Summary
- drop foreign key to `language_models` from `lexicostatistics`
- simplify `lexicostatistics.py` to write ensembles without touching `language_models`

## Testing
- `uv run -- python -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6871ed7750ec8325a8c093ed0db36a95