### PR TITLE
Enhance dataset release charts

### DIFF
--- a/chartutils.py
+++ b/chartutils.py
@@ -21,7 +21,11 @@ def draw_baselines(ax, df, xpos=12.5):
     colours = {
         'logistic regression': 'teal',
         'decision trees': 'gold',
-        'dummy': 'orange'
+        'dummy': 'orange',
+        'rulefit': 'purple',
+        'bayesian rule list': 'brown',
+        'corels': 'pink',
+        'ebm': 'gray',
     }
     
     for model, colour in colours.items():


### PR DESCRIPTION
## Summary
- show all baseline model lines on release plots
- plot ensemble max scores with regression line and return coefficients
- add model and ensemble tables to dataset pages
- scatter plots no longer connect points

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f35f2a708325915ac0d663258e92