### PR TITLE
Use KT smoothing and select ensembles

### DIFF
--- a/chartutils.py
+++ b/chartutils.py
@@ -7,7 +7,7 @@ import math
 import matplotlib.pyplot as plt
 
 
-def draw_baselines(ax, df, xpos=12.5):
+def draw_baselines(ax, df, xpos=12.5, dataset_size=None):
     """Draw baseline model performance as horizontal lines on a plot.
     
     Args:
@@ -32,7 +32,7 @@ def draw_baselines(ax, df, xpos=12.5):
         if model in df.columns:
             # Don't need to take the mean -- they will all be the same value
             score = df[model].mean()
-            # Convert accuracy to negative log mean error
-            #score = -math.log10(1-score)
+            if dataset_size is not None and not math.isnan(score):
+                score = -math.log10((score * dataset_size + 0.5) / (dataset_size + 1))
             ax.axhline(score, linestyle='dotted', c=colours[model])
             ax.annotate(xy=(xpos, score-0.03), text=model.title(), c=colours[model])

--- a/modules/ensemble_selection.py
+++ b/modules/ensemble_selection.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Utility for selecting interesting ensembles for plotting."""
+
+from __future__ import annotations
+
+import argparse
+from typing import List, Tuple, Iterable
+
+import pandas as pd
+
+
+def get_interesting_ensembles(conn, dataset: str) -> pd.DataFrame:
+    """Return ensembles with strictly improving validation accuracy.
+
+    The input table ``ensemble_results`` may contain multiple rows per
+    release date. This function keeps the ensemble with the highest
+    validation accuracy for each date and then filters so that the
+    remaining rows show a monotonically increasing validation accuracy
+    over time.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT release_date, validation_accuracy, validation_correct,
+               validation_total, test_correct, test_total, model_names
+          FROM ensemble_results
+         WHERE dataset = %s
+         ORDER BY release_date, validation_accuracy DESC
+        """,
+        (dataset,),
+    )
+    rows = cur.fetchall()
+    if not rows:
+        return pd.DataFrame(
+            columns=[
+                "release_date",
+                "validation_accuracy",
+                "validation_correct",
+                "validation_total",
+                "test_correct",
+                "test_total",
+                "model_names",
+            ]
+        )
+
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "release_date",
+            "validation_accuracy",
+            "validation_correct",
+            "validation_total",
+            "test_correct",
+            "test_total",
+            "model_names",
+        ],
+    )
+
+    df.sort_values(["release_date", "validation_accuracy"], ascending=[True, False], inplace=True)
+    df = df.drop_duplicates(subset=["release_date"], keep="first")
+    df.sort_values("release_date", inplace=True)
+
+    best_so_far = -1.0
+    keep_rows = []
+    for idx, row in df.iterrows():
+        val_acc = row["validation_accuracy"]
+        if val_acc is None:
+            continue
+        if val_acc > best_so_far:
+            best_so_far = val_acc
+            keep_rows.append(idx)
+
+    return df.loc[keep_rows]
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    from modules.postgres import get_connection
+
+    parser = argparse.ArgumentParser(description="List interesting ensembles")
+    parser.add_argument("dataset", help="Dataset name")
+    args = parser.parse_args(argv)
+
+    conn = get_connection()
+    df = get_interesting_ensembles(conn, args.dataset)
+    if df.empty:
+        print("No ensemble data found")
+    else:
+        for row in df.itertuples(index=False):
+            print(
+                row.release_date,
+                row.validation_accuracy,
+                row.test_correct,
+                row.test_total,
+                row.model_names,
+                sep="\t",
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add ensemble selector module with CLI
- compute Krichevsky–Trofimov (KT) smoothed accuracy for model and ensemble scores
- update website export to plot and tabulate KT values
- support KT baseline plotting

## Testing
- `python -m py_compile modules/ensemble_selection.py export_website.py chartutils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872c48cb0948325860504b918e9eebe