### PR TITLE
Fix KT calculation and expand website tables

### DIFF
--- a/chartutils.py
+++ b/chartutils.py
@@ -5,6 +5,7 @@ Utility functions for generating and formatting charts in the narrative-learning
 
 import math
 import matplotlib.pyplot as plt
+from modules.metrics import accuracy_to_kt
 
 
 def draw_baselines(ax, df, xpos=12.5, dataset_size=None):
@@ -33,6 +34,6 @@ def draw_baselines(ax, df, xpos=12.5, dataset_size=None):
             # Don't need to take the mean -- they will all be the same value
             score = df[model].mean()
             if dataset_size is not None and not math.isnan(score):
-                score = -math.log10((score * dataset_size + 0.5) / (dataset_size + 1))
+                score = accuracy_to_kt(score, dataset_size)
             ax.axhline(score, linestyle='dotted', c=colours[model])
             ax.annotate(xy=(xpos, score-0.03), text=model.title(), c=colours[model])

--- a/modules/metrics.py
+++ b/modules/metrics.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from typing import Dict, List, Any, Optional, Tuple, Union
 import pandas as pd
+import math
 
 def calculate_metric(matrix: Dict, metric_name: str) -> float:
     """
@@ -184,3 +185,8 @@ def create_metrics_dataframe(config, split_id: int, metric: str,
             df[column_name] = temp_df['metric']
 
     return df
+
+
+def accuracy_to_kt(accuracy: float, dataset_size: int) -> float:
+    """Convert an accuracy score to a KT value with smoothing."""
+    return -math.log10((accuracy * dataset_size + 0.5) / (dataset_size + 1))


### PR DESCRIPTION
## Summary
- centralize Krichevsky–Trofimov calculation in `accuracy_to_kt`
- use the helper in chart utils and website export
- show accuracy alongside KT scores on investigation pages
- sort round charts by creation time and add titles
- include accuracy, KT, patience and example counts on dataset pages
- add accuracy column to baseline results
- remove secondary accuracy axis from dataset charts

## Testing
- `uv run -- python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872feb8ee288325ae3deca1ba3ab51c