### PR TITLE
Fix ensemble naming and add best_yet flag

### DIFF
--- a/postgres-schemas/ensemble_results.sql
+++ b/postgres-schemas/ensemble_results.sql
@@ -17,5 +17,6 @@ CREATE TABLE IF NOT EXISTS ensemble_results (
     test_total INTEGER,
     test_correct INTEGER,
     created TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    best_yet BOOLEAN DEFAULT FALSE,
     PRIMARY KEY (dataset, k, models)
 );


### PR DESCRIPTION
## Summary
- use the model's `name` when pulling investigations
- add a `best_yet` column to `ensemble_results` and update insert logic
- mark rows as `best_yet` when they beat all earlier ensembles
- remove table creation from `store_results_in_db`

## Testing
- `bash envsetup.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687396987354832586a8420e890824ef