### PR TITLE
Save baseline models per-feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ PGUSER=root uv run baseline.py --dataset <dataset>
 `baseline.py` will look up the configuration path for the given dataset from
 the `datasets` table if `--config` is not supplied.
 
-Run this once per dataset to fill the `baseline_results` table.
+Run this once per dataset to fill the `baseline_results` table and the `baseline_*` tables.
+Each `baseline_*` table stores interpretable model data (e.g. logistic regression
+weights or decision tree graphs) so the website can display the trained models.
 
 Then copy everything from `outputs/*_results.csv`
 

--- a/baseline.py
+++ b/baseline.py
@@ -156,8 +156,75 @@ def preprocess_data(train_df, test_df, config):
     return X_train, y_train, X_test, y_test, feature_names, numeric_continuous_indices
 
 
-def train_and_evaluate_models(X_train, y_train, X_test, y_test, numeric_continuous_indices):
-    """Train multiple baseline models and return accuracy metrics."""
+def extract_model_representation(name, clf, feature_names):
+    """Return structured data representing a trained model."""
+    try:
+        if name == 'logistic regression':
+            rows = [('intercept', float(clf.intercept_[0]))]
+            rows += [
+                (feature, float(weight))
+                for feature, weight in zip(feature_names, clf.coef_[0])
+            ]
+            return rows
+        if name == 'decision trees':
+            from io import StringIO
+            from sklearn.tree import export_graphviz
+
+            buf = StringIO()
+            export_graphviz(clf, out_file=buf, feature_names=feature_names)
+            return buf.getvalue()
+        if name == 'dummy':
+            if hasattr(clf, 'constant_'):
+                return str(clf.constant_[0])
+            return str(clf)
+        if name == 'RuleFit':
+            try:
+                df = clf.get_rules()
+            except Exception:
+                return []
+            rows = []
+            idx = 0
+            for _, r in df.iterrows():
+                if r.get('type') == 'rule':
+                    rows.append((idx, r['rule'], float(r['coef'])))
+                    idx += 1
+            return rows
+        if name == 'BayesianRuleList':
+            rows = []
+            for i, rule in enumerate(getattr(clf, 'rule_list_', [])):
+                prob = getattr(rule, 'p', None)
+                prob = float(prob) if prob is not None else None
+                rows.append((i, str(rule), prob))
+            return rows
+        if name == 'CORELS':
+            rows = []
+            rules = getattr(getattr(clf, 'rl', None), 'rules', [])
+            for i, rule in enumerate(rules):
+                rows.append((i, str(rule)))
+            return rows
+        if name == 'EBM':
+            rows = []
+            additive = getattr(clf, 'additive_terms_', [])
+            for fname, term in zip(feature_names, additive):
+                try:
+                    rows.append((fname, json.dumps(term.tolist())))
+                except Exception:
+                    rows.append((fname, json.dumps(term)))
+            return rows
+    except Exception:
+        pass
+    return None
+
+
+def train_and_evaluate_models(
+    X_train,
+    y_train,
+    X_test,
+    y_test,
+    numeric_continuous_indices,
+    feature_names,
+):
+    """Train multiple baseline models and return accuracy metrics and representations."""
     from statsmodels.stats.proportion import proportion_confint
 
     models = {
@@ -198,6 +265,7 @@ def train_and_evaluate_models(X_train, y_train, X_test, y_test, numeric_continuo
         X_train_discrete, X_test_discrete = X_train, X_test
 
     accuracies = {}
+    representations = {}
     for name, clf in models.items():
         if name in {'BayesianRuleList', 'CORELS'}:
             clf.fit(X_train_discrete, y_train)
@@ -205,6 +273,7 @@ def train_and_evaluate_models(X_train, y_train, X_test, y_test, numeric_continuo
         else:
             clf.fit(X_train, y_train)
             accuracies[name] = clf.score(X_test, y_test)
+        representations[name] = extract_model_representation(name, clf, feature_names)
 
     n_test = len(y_test)
     correct_counts = {name: round(acc * n_test) for name, acc in accuracies.items()}
@@ -232,7 +301,7 @@ def train_and_evaluate_models(X_train, y_train, X_test, y_test, numeric_continuo
     for name in models:
         print(f"{name}: accuracy = {accuracies[name]:.4f} (95% CI Lower Bound: {lower_bounds[name]:.4f})")
 
-    return output
+    return output, representations
 
 
 def main():
@@ -270,7 +339,14 @@ def main():
         sys.exit("Error: No usable features found after preprocessing")
 
     # Train and evaluate models
-    results = train_and_evaluate_models(X_train, y_train, X_test, y_test, numeric_continuous_indices)
+    results, representations = train_and_evaluate_models(
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        numeric_continuous_indices,
+        feature_names,
+    )
 
     if args.output:
         with open(args.output, 'w') as f:
@@ -289,6 +365,74 @@ def main():
                 bayesian_rule_list DOUBLE PRECISION,
                 corels DOUBLE PRECISION,
                 ebm DOUBLE PRECISION
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS baseline_logreg (
+                dataset TEXT REFERENCES datasets(dataset),
+                feature TEXT,
+                weight DOUBLE PRECISION,
+                PRIMARY KEY (dataset, feature)
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS baseline_decision_tree (
+                dataset TEXT PRIMARY KEY REFERENCES datasets(dataset),
+                dot_data TEXT
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS baseline_dummy (
+                dataset TEXT PRIMARY KEY REFERENCES datasets(dataset),
+                constant_value TEXT
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS baseline_rulefit (
+                dataset TEXT REFERENCES datasets(dataset),
+                rule_index INTEGER,
+                rule TEXT,
+                weight DOUBLE PRECISION,
+                PRIMARY KEY (dataset, rule_index)
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS baseline_bayesian_rule_list (
+                dataset TEXT REFERENCES datasets(dataset),
+                rule_order INTEGER,
+                rule TEXT,
+                probability DOUBLE PRECISION,
+                PRIMARY KEY (dataset, rule_order)
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS baseline_corels (
+                dataset TEXT REFERENCES datasets(dataset),
+                rule_order INTEGER,
+                rule TEXT,
+                PRIMARY KEY (dataset, rule_order)
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS baseline_ebm (
+                dataset TEXT REFERENCES datasets(dataset),
+                feature TEXT,
+                contribution_data JSONB,
+                PRIMARY KEY (dataset, feature)
             )
             """
         )
@@ -318,6 +462,48 @@ def main():
                 results['EBM']['lower_bound'],
             ),
         )
+        cur.execute("DELETE FROM baseline_logreg WHERE dataset = %s", (dataset,))
+        cur.executemany(
+            "INSERT INTO baseline_logreg (dataset, feature, weight) VALUES (%s, %s, %s)",
+            [ (dataset, feat, weight) for feat, weight in representations.get("logistic regression", []) ],
+        )
+
+        cur.execute("DELETE FROM baseline_decision_tree WHERE dataset = %s", (dataset,))
+        dot = representations.get("decision trees")
+        if dot is not None:
+            cur.execute(
+                "INSERT INTO baseline_decision_tree (dataset, dot_data) VALUES (%s, %s)",
+                (dataset, dot),
+            )
+
+        cur.execute("INSERT INTO baseline_dummy (dataset, constant_value) VALUES (%s, %s)"
+                    " ON CONFLICT (dataset) DO UPDATE SET constant_value = EXCLUDED.constant_value",
+                    (dataset, representations.get("dummy")))
+
+        cur.execute("DELETE FROM baseline_rulefit WHERE dataset = %s", (dataset,))
+        cur.executemany(
+            "INSERT INTO baseline_rulefit (dataset, rule_index, rule, weight) VALUES (%s, %s, %s, %s)",
+            [ (dataset, idx, rule, wt) for idx, rule, wt in representations.get("RuleFit", []) ],
+        )
+
+        cur.execute("DELETE FROM baseline_bayesian_rule_list WHERE dataset = %s", (dataset,))
+        cur.executemany(
+            "INSERT INTO baseline_bayesian_rule_list (dataset, rule_order, rule, probability) VALUES (%s, %s, %s, %s)",
+            [ (dataset, idx, rule, prob) for idx, rule, prob in representations.get("BayesianRuleList", []) ],
+        )
+
+        cur.execute("DELETE FROM baseline_corels WHERE dataset = %s", (dataset,))
+        cur.executemany(
+            "INSERT INTO baseline_corels (dataset, rule_order, rule) VALUES (%s, %s, %s)",
+            [ (dataset, idx, rule) for idx, rule in representations.get("CORELS", []) ],
+        )
+
+        cur.execute("DELETE FROM baseline_ebm WHERE dataset = %s", (dataset,))
+        cur.executemany(
+            "INSERT INTO baseline_ebm (dataset, feature, contribution_data) VALUES (%s, %s, %s)",
+            [ (dataset, feat, contrib) for feat, contrib in representations.get("EBM", []) ],
+        )
+
         conn.commit()
 
     # Close database connection

--- a/export_website.py
+++ b/export_website.py
@@ -447,6 +447,86 @@ def generate_dataset_page(conn, dataset: str, cfg_file: str, out_dir: str) -> No
             body.append(f"<tr><td>{name}</td><td>{display_acc}</td><td>{display_kt}</td></tr>")
         body.append("</table>")
 
+        body.append("<h2>Baseline Models</h2>")
+
+        cur.execute(
+            "SELECT feature, weight FROM baseline_logreg WHERE dataset = %s ORDER BY feature",
+            (dataset,),
+        )
+        rows = cur.fetchall()
+        if rows:
+            body.append("<h3>Logistic Regression</h3>")
+            body.append("<table border='1'><tr><th>Feature</th><th>Weight</th></tr>")
+            for feat, wt in rows:
+                body.append(f"<tr><td>{html.escape(feat)}</td><td>{wt:.3f}</td></tr>")
+            body.append("</table>")
+
+        cur.execute(
+            "SELECT dot_data FROM baseline_decision_tree WHERE dataset = %s",
+            (dataset,),
+        )
+        row = cur.fetchone()
+        if row and row[0]:
+            body.append("<h3>Decision Tree</h3>")
+            body.append(f"<pre class='graphviz'>{html.escape(row[0])}</pre>")
+
+        cur.execute(
+            "SELECT constant_value FROM baseline_dummy WHERE dataset = %s",
+            (dataset,),
+        )
+        row = cur.fetchone()
+        if row and row[0] is not None:
+            body.append("<h3>Dummy</h3>")
+            body.append("<pre>" + html.escape(str(row[0])) + "</pre>")
+
+        cur.execute(
+            "SELECT rule_index, rule, weight FROM baseline_rulefit WHERE dataset = %s ORDER BY rule_index",
+            (dataset,),
+        )
+        rows = cur.fetchall()
+        if rows:
+            body.append("<h3>RuleFit</h3>")
+            body.append("<table border='1'><tr><th>#</th><th>Rule</th><th>Weight</th></tr>")
+            for idx, rule, wt in rows:
+                body.append(f"<tr><td>{idx}</td><td>{html.escape(rule)}</td><td>{wt:.3f}</td></tr>")
+            body.append("</table>")
+
+        cur.execute(
+            "SELECT rule_order, rule, probability FROM baseline_bayesian_rule_list WHERE dataset = %s ORDER BY rule_order",
+            (dataset,),
+        )
+        rows = cur.fetchall()
+        if rows:
+            body.append("<h3>Bayesian Rule List</h3>")
+            body.append("<table border='1'><tr><th>#</th><th>Rule</th><th>Probability</th></tr>")
+            for idx, rule, prob in rows:
+                body.append(f"<tr><td>{idx}</td><td>{html.escape(rule)}</td><td>{prob:.3f}</td></tr>")
+            body.append("</table>")
+
+        cur.execute(
+            "SELECT rule_order, rule FROM baseline_corels WHERE dataset = %s ORDER BY rule_order",
+            (dataset,),
+        )
+        rows = cur.fetchall()
+        if rows:
+            body.append("<h3>CORELS</h3>")
+            body.append("<ol>")
+            for _, rule in rows:
+                body.append(f"<li>{html.escape(rule)}</li>")
+            body.append("</ol>")
+
+        cur.execute(
+            "SELECT feature, contribution_data FROM baseline_ebm WHERE dataset = %s ORDER BY feature",
+            (dataset,),
+        )
+        rows = cur.fetchall()
+        if rows:
+            body.append("<h3>EBM</h3>")
+            body.append("<table border='1'><tr><th>Feature</th><th>Contribution Data</th></tr>")
+            for feat, contrib in rows:
+                body.append(f"<tr><td>{html.escape(feat)}</td><td>{html.escape(str(contrib))}</td></tr>")
+            body.append("</table>")
+
     write_page(os.path.join(out_dir, "index.html"), f"Dataset {dataset}", "\n".join(body))
 
 

--- a/postgres-schemas/investigations_schema.sql
+++ b/postgres-schemas/investigations_schema.sql
@@ -33,3 +33,50 @@ CREATE TABLE baseline_results (
     corels DOUBLE PRECISION,
     ebm DOUBLE PRECISION
 );
+
+CREATE TABLE baseline_logreg (
+    dataset TEXT REFERENCES datasets(dataset),
+    feature TEXT,
+    weight DOUBLE PRECISION,
+    PRIMARY KEY (dataset, feature)
+);
+
+CREATE TABLE baseline_decision_tree (
+    dataset TEXT PRIMARY KEY REFERENCES datasets(dataset),
+    dot_data TEXT
+);
+
+CREATE TABLE baseline_dummy (
+    dataset TEXT PRIMARY KEY REFERENCES datasets(dataset),
+    constant_value TEXT
+);
+
+CREATE TABLE baseline_rulefit (
+    dataset TEXT REFERENCES datasets(dataset),
+    rule_index INTEGER,
+    rule TEXT,
+    weight DOUBLE PRECISION,
+    PRIMARY KEY (dataset, rule_index)
+);
+
+CREATE TABLE baseline_bayesian_rule_list (
+    dataset TEXT REFERENCES datasets(dataset),
+    rule_order INTEGER,
+    rule TEXT,
+    probability DOUBLE PRECISION,
+    PRIMARY KEY (dataset, rule_order)
+);
+
+CREATE TABLE baseline_corels (
+    dataset TEXT REFERENCES datasets(dataset),
+    rule_order INTEGER,
+    rule TEXT,
+    PRIMARY KEY (dataset, rule_order)
+);
+
+CREATE TABLE baseline_ebm (
+    dataset TEXT REFERENCES datasets(dataset),
+    feature TEXT,
+    contribution_data JSONB,
+    PRIMARY KEY (dataset, feature)
+);


### PR DESCRIPTION
## Summary
- store baseline model details in structured tables (weights, rules, etc.)
- show stored baseline models on dataset pages
- mention interpretable baseline tables in the README

## Testing
- `python -m py_compile baseline.py export_website.py`
- `python -m unittest test_env_settings.py test_postgres.py`


------
https://chatgpt.com/codex/tasks/task_e_6872ff0d8f3c8325aece79a0d46edc90