### PR TITLE
Fix model index key and guard r² calculation

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -649,7 +649,7 @@ def generate_model_index_page(rows: List[tuple[str, datetime, str, str, int]], o
     ]
     table: dict[tuple[str, str, str], dict[int, list[str]]] = {}
     for vendor, release_date, training_model, model, ex in rows:
-        key = (vendor, training_model, str(release_date.date()))
+        key = (vendor, training_model, str(release_date))
         table.setdefault(key, {3: [], 10: []})
         if ex in (3, 10):
             table[key][ex].append(model)

--- a/modules/text_analysis.py
+++ b/modules/text_analysis.py
@@ -111,7 +111,10 @@ def calculate_zipfs_law(text_list: List[str]) -> Dict[str, Union[float, dict]]:
         y_pred = slope * log_ranks + intercept
         ss_total = np.sum((log_frequencies - np.mean(log_frequencies))**2)
         ss_residual = np.sum((log_frequencies - y_pred)**2)
-        r_squared = 1 - (ss_residual / ss_total)
+        if ss_total == 0:
+            r_squared = 0.0
+        else:
+            r_squared = 1 - (ss_residual / ss_total)
         
         zipf_coefficients.append(zipf_coefficient)
         r_squared_values.append(r_squared)
@@ -207,7 +210,10 @@ def calculate_herdans_law(text_list: List[str]) -> Dict[str, Union[float, dict]]
         y_pred = slope * log_text_lengths + intercept
         ss_total = np.sum((log_vocab_sizes - np.mean(log_vocab_sizes))**2)
         ss_residual = np.sum((log_vocab_sizes - y_pred)**2)
-        r_squared = 1 - (ss_residual / ss_total)
+        if ss_total == 0:
+            r_squared = 0.0
+        else:
+            r_squared = 1 - (ss_residual / ss_total)
         
         herdan_coefficients.append(herdan_coefficient)
         r_squared_values.append(r_squared)


### PR DESCRIPTION
## Summary
- fix `release_date` handling for model index page generation
- avoid division by zero warnings when computing r² values

## Testing
- `PGUSER=root .venv/bin/pytest -q`
- `PGUSER=root PGDATABASE=narrative uv run python export_website.py --progress-bar`

------
https://chatgpt.com/codex/tasks/task_e_6874c4880e048325b20c74a6047688d7