### PR TITLE
Update dataset release charts

### DIFF
--- a/chartutils.py
+++ b/chartutils.py
@@ -4,36 +4,53 @@ Utility functions for generating and formatting charts in the narrative-learning
 """
 
 import math
+import numpy as np
 import matplotlib.pyplot as plt
 from modules.metrics import accuracy_to_kt
 
 
-def draw_baselines(ax, df, xpos=12.5, dataset_size=None):
+def draw_baselines(ax, df, xpos=None, dataset_size=None):
     """Draw baseline model performance as horizontal lines on a plot.
-    
+
     Args:
         ax: Matplotlib axes object to draw on
         df: DataFrame containing baseline columns
-        xpos: X-position for annotation labels (default: 12.5)
-    
+        xpos: If provided, the maximum x-position used to calculate label
+            placement. When ``None``, the function will use the current axis
+            limits to determine label spacing.
+
     Returns:
         None, modifies ax in-place
     """
     colours = {
-        'logistic regression': 'teal',
-        'decision trees': 'gold',
-        'dummy': 'orange',
-        'rulefit': 'purple',
-        'bayesian rule list': 'brown',
-        'corels': 'pink',
-        'ebm': 'gray',
+        "logistic regression": "teal",
+        "decision trees": "gold",
+        "dummy": "orange",
+        "rulefit": "purple",
+        "bayesian rule list": "brown",
+        "corels": "pink",
+        "ebm": "gray",
     }
-    
-    for model, colour in colours.items():
-        if model in df.columns:
-            # Don't need to take the mean -- they will all be the same value
-            score = df[model].mean()
-            if dataset_size is not None and not math.isnan(score):
-                score = -accuracy_to_kt(score, dataset_size)
-            ax.axhline(score, linestyle='dotted', c=colours[model])
-            ax.annotate(xy=(xpos, score-0.03), text=model.title(), c=colours[model])
+
+    names = [m for m in colours if m in df.columns]
+    if not names:
+        return
+
+    xlim = ax.get_xlim()
+    if xpos is None:
+        start, end = xlim
+    else:
+        start, end = xlim[0], xpos
+    x_positions = np.linspace(start, end, len(names))
+
+    for model, xpos_val in zip(names, x_positions):
+        score = df[model].mean()
+        if dataset_size is not None and not math.isnan(score):
+            score = -accuracy_to_kt(score, dataset_size)
+        ax.axhline(score, linestyle="dotted", c=colours[model])
+        ax.annotate(
+            xy=(xpos_val, score - 0.03),
+            text=model.title(),
+            c=colours[model],
+            ha="center",
+        )


### PR DESCRIPTION
## Summary
- spread out baseline labels to avoid overlap
- show dataset name in dataset release chart title
- rename y-axis to `-log10 KT accuracy`
- plot vertical marker for when ensembles surpass the best baseline

## Testing
- `uv pip install pytest`
- `PGUSER=root uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f2bbd11c8325ad9f47cf127d38c9