### PR TITLE
Add predict_many and update process_round

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -102,6 +102,26 @@ Entity Data:
     config.conn.commit()
 
 
+def predict_many(
+    config,
+    round_id,
+    entity_ids,
+    model: str = "phi4:latest",
+    dry_run: bool = False,
+    investigation_id: int | None = None,
+):
+    """Run :func:`predict` for multiple entity IDs.
+
+    ``entity_ids`` can be an iterable of IDs or ``(id, unique_id)`` tuples. The
+    unique identifier is ignored for now but allows callers to verify that the
+    prediction corresponds to the expected entity in future implementations.
+    """
+
+    for item in entity_ids:
+        entity_id = item[0] if isinstance(item, tuple) else item
+        predict(config, round_id, entity_id, model=model, dry_run=dry_run, investigation_id=investigation_id)
+
+
 
 if __name__ == '__main__':
     default_model = os.environ.get('NARRATIVE_LEARNING_INFERENCE_MODEL', None)

--- a/process_round.py
+++ b/process_round.py
@@ -75,13 +75,24 @@ def main():
             import tqdm
             iterator = tqdm.tqdm(cur.fetchall())
         anything_left = False
+        ids_to_predict = []
         for row in iterator:
             anything_left = True
             if args.list:
                 print(row[0])
                 continue
-            predict.predict(config, args.round_id, row[0], model=args.model, investigation_id=args.investigation_id)
-            predictions_done += 1
+            ids_to_predict.append(row[0])
+            if args.stop_after is not None and predictions_done + len(ids_to_predict) >= args.stop_after:
+                break
+        if ids_to_predict:
+            predict.predict_many(
+                config,
+                args.round_id,
+                ids_to_predict,
+                model=args.model,
+                investigation_id=args.investigation_id,
+            )
+            predictions_done += len(ids_to_predict)
             if args.stop_after is not None and predictions_done >= args.stop_after:
                 sys.exit(0)
         if not anything_left:


### PR DESCRIPTION
## Summary
- support multiple entity predictions with `predict_many`
- process rounds using the new helper

## Testing
- `PGUSER=root uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68757c0a0ff483259a94d78f35b9761d