### PR TITLE
Add JSONL batch support for OpenAI inference

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -8,6 +8,28 @@ import llmcall
 import datasetconfig
 from modules.postgres import get_connection, get_investigation_settings
 
+
+def _make_prompt(config, round_id: int, entity_id: str) -> tuple[str, str]:
+    """Return the prompt and round instructions for ``entity_id``."""
+
+    instructions = config.get_round_prompt(round_id)
+    if instructions is None:
+        sys.exit(f"Round ID {round_id} not found.")
+
+    entity_features = config.get_entity_features(entity_id)
+
+    prompt = f"""This is an experiment in identifying whether an LLM can predict outcomes. Use the following methodology for predicting the outcome for this entity.
+
+```
+{instructions}
+```
+
+Entity Data:
+{entity_features}
+"""
+
+    return prompt, instructions
+
 class AlreadyPredictedException(Exception):
     """Exception raised when a prediction has already been made for a specific primary key in a round.
 
@@ -41,10 +63,7 @@ def predict(config, round_id, entity_id, model='gpt-4.1-mini', dry_run=False,
     # Create a DatasetConfig object
     cursor = config.conn.cursor()
 
-    # Get the round instructions
-    instructions = config.get_round_prompt(round_id)
-    if instructions is None:
-        sys.exit(f"Round ID {round_id} not found.")
+    prompt, instructions = _make_prompt(config, round_id, entity_id)
 
     inf_table = f"{config.dataset}_inferences" if getattr(config, "dataset", "") else "inferences"
     query = f"SELECT COUNT(*) FROM {inf_table} WHERE round_id = ? AND {config.primary_key} = ?"
@@ -53,19 +72,7 @@ def predict(config, round_id, entity_id, model='gpt-4.1-mini', dry_run=False,
     if row[0] == 1 and not (dry_run or prompt_only):
         raise AlreadyPredictedException(entity_id, round_id)
 
-    # Get the entity features
-    entity_features = config.get_entity_features(entity_id)
 
-    # Create the prompt
-    prompt = f"""This is an experiment in identifying whether an LLM can predict outcomes. Use the following methodology for predicting the outcome for this entity.
-
-```
-{instructions}
-```
-
-Entity Data:
-{entity_features}
-"""
 
     if prompt_only:
         print(prompt)
@@ -128,6 +135,36 @@ def predict_many(
         predict(config, round_id, entity_id, model=model, dry_run=dry_run, prompt_only=prompt_only, investigation_id=investigation_id)
 
 
+def jsonl_many(config, round_id, entity_ids, model: str, output_file: str):
+    """Write OpenAI batch requests for the given entity IDs."""
+
+    for item in entity_ids:
+        entity_id = item[0] if isinstance(item, tuple) else item
+
+        cursor = config.conn.cursor()
+        inf_table = f"{config.dataset}_inferences" if getattr(config, "dataset", "") else "inferences"
+        query = f"SELECT COUNT(*) FROM {inf_table} WHERE round_id = ? AND {config.primary_key} = ?"
+        config._execute(cursor, query, (round_id, entity_id))
+        row = cursor.fetchone()
+        if row[0] == 1:
+            raise AlreadyPredictedException(entity_id, round_id)
+
+        prompt, instructions = _make_prompt(config, round_id, entity_id)
+
+        if instructions == "Choose randomly":
+            raise ValueError("Cannot create JSONL for 'Choose randomly' instructions")
+
+        body = llmcall.openai_request_json(model, prompt, config.valid_predictions)
+        batch_text = {
+            "custom_id": str(entity_id),
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": body,
+        }
+        with open(output_file, "a") as f:
+            f.write(json.dumps(batch_text) + "\n")
+
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -151,6 +188,7 @@ if __name__ == '__main__':
                         help="Just show the prompt, then exit")
     parser.add_argument("--model", help="AI model to use for prediction", default="gpt-4.1-mini")
     parser.add_argument("--config", help="The JSON config file that says what columns exist and what the tables are called")
+    parser.add_argument("--jsonl", help="Write OpenAI batch requests to this file instead of running predictions")
     args = parser.parse_args()
 
     if args.investigation_id is not None:
@@ -165,7 +203,11 @@ if __name__ == '__main__':
         conn = get_connection(args.dsn, args.pg_config)
         config = datasetconfig.DatasetConfig(conn, args.config)
 
-    if len(args.entity_id) > 1:
+    if args.jsonl:
+        if not llmcall.is_openai_model(args.model):
+            sys.exit("--jsonl can only be used with OpenAI models")
+        jsonl_many(config, args.round_id, args.entity_id, args.model, args.jsonl)
+    else:
         predict_many(
             config,
             args.round_id,
@@ -174,14 +216,4 @@ if __name__ == '__main__':
             dry_run=args.dry_run,
             prompt_only=args.prompt_only,
             investigation_id=args.investigation_id,
-        )
-    else:
-        predict(
-            config,
-            args.round_id,
-            args.entity_id[0],
-            args.model,
-            args.dry_run,
-            args.prompt_only,
-            args.investigation_id,
         )


### PR DESCRIPTION
## Summary
- introduce `OPENAI_MODELS`, `is_openai_model()` and `openai_request_json()` helper functions
- add `_make_prompt` helper in `predict.py`
- generate JSONL batch files with new `--jsonl` option
- always use `predict_many()` for prediction path

## Testing
- `pytest -q`
- `python -m py_compile predict.py llmcall.py`

------
https://chatgpt.com/codex/tasks/task_e_6875ce0c81488325839bfa30a0747543