### PR TITLE
Refactor predict_many to support OpenAI batch

### DIFF
--- a/process_round.py
+++ b/process_round.py
@@ -85,12 +85,19 @@ def main():
             if args.stop_after is not None and predictions_done + len(ids_to_predict) >= args.stop_after:
                 break
         if ids_to_predict:
+            if args.progress_bar:
+                import tqdm
+                pb = tqdm.tqdm(total=len(ids_to_predict))
+            else:
+                pb = None
             predict.predict_many(
                 config,
                 args.round_id,
                 ids_to_predict,
                 model=args.model,
                 investigation_id=args.investigation_id,
+                immediate=True,
+                progressbar=pb,
             )
             predictions_done += len(ids_to_predict)
             if args.stop_after is not None and predictions_done >= args.stop_after:


### PR DESCRIPTION
## Summary
- expand `predict_many` to handle OpenAI batch requests
- call the new function from CLI with progress bar support
- update `process_round` to use `predict_many` with `immediate=True`

## Testing
- `PGUSER=root uv run python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6876040d5b708325993ed9043740a101