### PR TITLE
Update progress bar handling in process_round

### DIFF
--- a/process_round.py
+++ b/process_round.py
@@ -70,10 +70,13 @@ def main():
         """
         config._execute(cur, query, (args.round_id,))
         # I think I should try doing a fetchall so that tqdm knows the appropriate length
-        iterator = cur
+        rows = cur.fetchall() if args.progress_bar else cur
+        iterator = rows
+        pb = None
         if args.progress_bar:
             import tqdm
-            iterator = tqdm.tqdm(cur.fetchall())
+            iterator = rows
+            pb = tqdm.tqdm(total=len(rows))
         anything_left = False
         ids_to_predict = []
         for row in iterator:
@@ -85,11 +88,6 @@ def main():
             if args.stop_after is not None and predictions_done + len(ids_to_predict) >= args.stop_after:
                 break
         if ids_to_predict:
-            if args.progress_bar:
-                import tqdm
-                pb = tqdm.tqdm(total=len(ids_to_predict))
-            else:
-                pb = None
             predict.predict_many(
                 config,
                 args.round_id,


### PR DESCRIPTION
## Summary
- create the progress bar when `--progress-bar` is enabled
- pass the bar to `predict.predict_many`

## Testing
- `PGUSER=root uv run python test_env_settings.py`
- `PGUSER=root uv run python test_postgres.py`


------
https://chatgpt.com/codex/tasks/task_e_6876482776d483259a3de9e99e9e39b8