### PR TITLE
Improve investigation page info and chart

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -279,6 +279,7 @@ def generate_investigation_page(
         ],
     )
     body = ["<ul>"]
+    body.append(f"<li>Dataset: {dataset}</li>")
     body.append(f"<li>Model: {model}</li>")
     body.append(f"<li>Training model: {training_model}</li>")
     body.append(f"<li>Inference model: {inference_model}</li>")
@@ -340,9 +341,17 @@ def generate_investigation_page(
     plt.plot(plot_df["rank"], plot_df["train_acc"], label="train")
     plt.plot(plot_df["rank"], plot_df["val_acc"], label="validation")
     plt.plot(plot_df["rank"], plot_df["test_acc"], label="test")
-    plt.xticks(plot_df["rank"], plot_df["round_id"])
+    if len(plot_df) > 20:
+        ticks = plot_df["rank"]
+        labels = [
+            r_id if (i + 1) % 5 == 0 else ""
+            for i, r_id in enumerate(plot_df["round_id"])
+        ]
+        plt.xticks(ticks, labels)
+    else:
+        plt.xticks(plot_df["rank"], plot_df["round_id"])
     plt.xlabel("Round")
-    plt.ylabel("log10 KT accuracy")
+    plt.ylabel("Negative log10 KT score")
     plt.title("Round Scores")
     plt.legend()
     plt.tight_layout()


### PR DESCRIPTION
## Summary
- show dataset name on investigation pages
- avoid cluttered x-axis labels for charts with more than 20 rounds by labelling every fifth round
- clarify y-axis label for round score chart

## Testing
- `PGUSER=root PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --quiet python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876c382d4cc8325bcbb7e506a4538f7