### PR TITLE
Add uv reminder for running tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,5 @@ can inspect it with `psql -U root narrative` or connect from Python using
 
 When testing scripts that use libpq defaults, set the `PGUSER` environment
 variable to `root` so connections are made with the correct role.
+
+When running tests, always use `uv run pytest`. Running pytest directly usually fails.


### PR DESCRIPTION
## Summary
- document that tests should be run with `uv`

## Testing
- `uv run -- python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877533e7d388325ab49053537c187a4