### PR TITLE
Filter zero-valued lexicostatistics results

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -919,7 +919,11 @@ def generate_lexicostatistics_page(conn, out_dir: str) -> dict[str, tuple[float,
          ORDER BY lm.release_date
         """
     )
-    rows = cur.fetchall()
+    rows = [
+        row
+        for row in cur.fetchall()
+        if not any(v == 0 for v in row[3:])
+    ]
     df = pd.DataFrame(
         rows,
         columns=[
@@ -1034,7 +1038,11 @@ def generate_lexicostatistics_page(conn, out_dir: str) -> dict[str, tuple[float,
         "SELECT training_model, prompt_herdan, prompt_zipf, reasoning_herdan, reasoning_zipf FROM lexicostatistics WHERE training_model = ANY(%s)",
         ([r[1] for r in ens_rows],),
     )
-    lookup = {m: (ph, pz, rh, rz) for m, ph, pz, rh, rz in cur.fetchall()}
+    lookup = {
+        m: (ph, pz, rh, rz)
+        for m, ph, pz, rh, rz in cur.fetchall()
+        if not any(v == 0 for v in (ph, pz, rh, rz))
+    }
     data = []
     for date, models in ens_rows:
         if models in lookup:


### PR DESCRIPTION
## Summary
- ignore models and ensembles with any 0-valued lexicostatistics when building `lexicostatistics/index.html`
- keep trend calculations and charts based only on valid data

## Testing
- `PGUSER=root uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b5def89e08325bd380d378b7562ad