### PR TITLE
Fix ensemble query

### DIFF
--- a/results_ensembling.py
+++ b/results_ensembling.py
@@ -732,11 +732,10 @@ if __name__ == '__main__':
 
     cur.execute(
         """
-        SELECT i.id, m.name
-          FROM investigations i
-          JOIN models m ON i.model = m.model
-         WHERE i.dataset = %s
-         ORDER BY i.id
+        SELECT id, model
+          FROM investigations
+         WHERE dataset = %s
+         ORDER BY id
         """,
         (args.dataset,),
     )


### PR DESCRIPTION
## Summary
- results_ensembling.py: fetch model names from investigations table directly

## Testing
- `uv run results_ensembling.py --progress titanic` *(fails: At least 3 investigations are required for 3-ensemble, but only 1 found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd82f9df48325a8bf2c1432461440