### PR TITLE
Add feature scatter and UMAP support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,5 @@ dependencies = [
     "imodels>=2.0.0",
     "interpret>=0.6.12",
     "jinja2>=3.1.4",
+    "umap-learn>=0.5.5",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai
 psycopg2-binary>=2.9.9
 imodels
 interpret
+umap-learn


### PR DESCRIPTION
## Summary
- plot a scatter of dataset feature variables on dataset pages
- use UMAP with a fixed random state if more than two features
- include umap-learn in project dependencies

## Testing
- `python -m py_compile export_website.py`
- `uv pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688073ef78408325b1ed15402923e585