### PR TITLE
Fix docs for ensemble and lexicostatistics workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,23 +75,31 @@ PGUSER=root uv run baseline.py --dataset <dataset>
 uv run investigate.py <investigation-id>
 ```
 
-Copy everything from `outputs/*_results.csv` after each run and then
-generate ensemble summaries:
+After each round the results are written to PostgreSQL. Generate
+ensemble summaries directly from the database:
 
 ```bash
-python results_ensembling.py titanic --summary outputs/titanic_ensemble_summary.txt
-python results_ensembling.py wisconsin --summary outputs/wisconsin_ensemble_summary.txt
-python results_ensembling.py southgermancredit --summary outputs/southgermancredit_ensemble_summary.txt
-python results_ensembling.py potions --summary outputs/potions_ensemble_summary.txt
-python results_ensembling.py timetravel_insurance --summary outputs/timetravel_insurance_ensemble_summary.txt
-python results_ensembling.py espionage --summary outputs/espionage_ensemble_summary.txt
+uv run results_ensembling.py --progress titanic
+uv run results_ensembling.py --progress wisconsin
+uv run results_ensembling.py --progress southgermancredit
+uv run results_ensembling.py --progress --no-decodex espionage
+uv run results_ensembling.py --progress --no-decodex timetravel_insurance
+uv run results_ensembling.py --progress --no-decodex potions
 ```
 
 The ensemble script stores results in the `ensemble_results` table and
-orders them by model release date from `language_models`.
-Some older models such as `gpt-4.5-preview` have been removed from the
-OpenAI API and `gemini-2.0` now requires a paid account, so you may need
-to substitute newer model names.
+orders them by model release date from `language_models`. Some older
+models such as `gpt-4.5-preview` have been removed from the OpenAI API
+and `gemini-2.0` now requires a paid account, so you may need to
+substitute newer model names.
+
+Run `lexicostatistics.py` for each ensemble once the investigations have
+completed so that lexical statistics are available when exporting the
+website:
+
+```bash
+uv run lexicostatistics.py "anthropic,openai45,openai35"
+```
 
 
 

--- a/run_ensembling.sh
+++ b/run_ensembling.sh
@@ -5,4 +5,11 @@ uv run results_ensembling.py --progress wisconsin && \
 uv run results_ensembling.py --progress southgermancredit && \
 uv run results_ensembling.py --progress --no-decodex espionage && \
 uv run results_ensembling.py --progress --no-decodex timetravel_insurance && \
-uv run results_ensembling.py --progress --no-decodex potions
+uv run results_ensembling.py --progress --no-decodex potions && \
+psql -U "${PGUSER:-root}" -d narrative -Atc \
+  "SELECT DISTINCT models FROM ensemble_results WHERE best_yet" | \
+while IFS= read -r models; do
+    [ -z "$models" ] && continue
+    echo "Running lexicostatistics for $models"
+    uv run lexicostatistics.py "$models" || exit 1
+done


### PR DESCRIPTION
## Summary
- update README to remove stale CSV instructions
- document how to run results_ensembling.py directly from the database
- mention running lexicostatistics.py so export_website works
- run lexicostatistics automatically for best ensembles

## Testing
- `PGUSER=root uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6885b9a2c9f08325b8ab6239f19f099d