### PR TITLE
Fix ensemble script PG connection

### DIFF
--- a/run_ensembling.sh
+++ b/run_ensembling.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
+
 uv run results_ensembling.py --progress titanic && \
 uv run results_ensembling.py --progress wisconsin && \
 uv run results_ensembling.py --progress southgermancredit && \
 uv run results_ensembling.py --progress --no-decodex espionage && \
 uv run results_ensembling.py --progress --no-decodex timetravel_insurance && \
 uv run results_ensembling.py --progress --no-decodex potions && \
-psql -U "${PGUSER:-root}" -d narrative -Atc \
+psql -d narrative -Atc \
   "SELECT DISTINCT models FROM ensemble_results WHERE best_yet" | \
 while IFS= read -r models; do
     [ -z "$models" ] && continue


### PR DESCRIPTION
## Summary
- make `run_ensembling.sh` rely on the caller's PostgreSQL environment variables
- run lexicostatistics query without explicit `-U` parameter

## Testing
- `PGUSER=root uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869bc0d36c8325a35cf56231c4bc90