### PR TITLE
Fix ensemble query for lexicostatistics page

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -1113,9 +1113,10 @@ def generate_lexicostatistics_page(conn, out_dir: str) -> dict[str, tuple[float,
     # Ensemble trends
     cur.execute(
         """
-        SELECT DISTINCT ON (release_date) release_date, models
+        SELECT release_date, models
           FROM ensemble_results
-         ORDER BY release_date, test_accuracy DESC
+         WHERE best_yet
+         ORDER BY release_date
         """
     )
     ens_rows = cur.fetchall()


### PR DESCRIPTION
## Summary
- pull ensemble trend data only for best ensembles

## Testing
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6887d78f9aa48325a2df2100b0b083ba