### PR TITLE
Fix ensemble export for datasets without decodex

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -1257,7 +1257,10 @@ def _compute_ensemble_data(
             continue
         inv_id = row[0]
         cfg = DatasetConfig(conn, cfg_file, dataset, inv_id)
-        preds.append(get_predictions_for_round(cfg, r_id, validation=False))
+        use_decodex = "decodex" in cfg.columns
+        preds.append(
+            get_predictions_for_round(cfg, r_id, validation=False, use_decodex=use_decodex)
+        )
         matrix = cfg.get_confusion_matrix(
             r_id, example_count=1, on_holdout_data=True, on_test_data=True
         )


### PR DESCRIPTION
## Summary
- handle datasets that do not have a `decodex` column when generating ensemble pages

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888d37090448325bfbb3762855fb485