### PR TITLE
Fix SQL placeholder mismatch

### DIFF
--- a/results_ensembling.py
+++ b/results_ensembling.py
@@ -667,7 +667,7 @@ def store_results_in_db(conn, dataset: str, k: int, validation_results, test_res
                 validation_total, validation_correct,
                 test_accuracy, test_lower_bound, test_upper_bound,
                 test_total, test_correct, best_yet
-            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
             ON CONFLICT (dataset, k, models) DO UPDATE SET
                 model_names=EXCLUDED.model_names,
                 model_rounds=EXCLUDED.model_rounds,


### PR DESCRIPTION
## Summary
- fix placeholder count in `store_results_in_db` SQL query

## Testing
- `PGUSER=root PGDATABASE=narrative uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c931e8a84832594f73ae6d5a4bb3c