### PR TITLE
Add overwrite flag for lexicostatistics

### DIFF
--- a/run_ensembling.sh
+++ b/run_ensembling.sh
@@ -12,5 +12,5 @@ psql -d narrative -Atc \
 while IFS= read -r models; do
     [ -z "$models" ] && continue
     echo "Running lexicostatistics for $models"
-    uv run lexicostatistics.py "$models" || exit 1
+    uv run lexicostatistics.py --overwrite "$models" || exit 1
 done


### PR DESCRIPTION
## Summary
- ensure `run_ensembling.sh` overwrites existing lexicostatistics

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d1dad28448325891bfa90be1e8f17