### PR TITLE
Add hosted-only filter for incomplete investigations

### DIFF
--- a/find_incomplete_investigations.py
+++ b/find_incomplete_investigations.py
@@ -6,18 +6,32 @@ that early stopping conditions were met.  Early stopping is evaluated
 before flagging missing inference data so investigations that legitimately
 halted early are not reported as incomplete.
 """
+import argparse
 from modules.postgres import get_connection
 from modules.investigation_status import gather_incomplete_investigations
 
 
-def gather_missing(conn):
+def gather_missing(conn, hosted_only: bool = False):
     """Deprecated wrapper for backward compatibility."""
-    return gather_incomplete_investigations(conn)
+    return gather_incomplete_investigations(conn, hosted_only=hosted_only)
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="List investigations that appear to have missing data"
+    )
+    parser.add_argument(
+        "--hosted-only",
+        action="store_true",
+        help=(
+            "Only include investigations using models whose language model "
+            "is not marked as ollama_hosted"
+        ),
+    )
+    args = parser.parse_args()
+
     conn = get_connection()
-    missing = gather_missing(conn)
+    missing = gather_missing(conn, hosted_only=args.hosted_only)
     conn.close()
 
     if not missing:


### PR DESCRIPTION
## Summary
- add a `--hosted-only` option to `find_incomplete_investigations.py`
- support the filter inside `gather_incomplete_investigations`

## Testing
- `flake8 find_incomplete_investigations.py modules/investigation_status.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_688d61d6229c8325ad6e8614da88dd32