### PR TITLE
Add cron automation and track incomplete investigations

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-export PGUSER="root"
-export PGDATABASE="narrative"
-
 # Update repository
 git pull -q
 
 # Record incomplete investigation counts
-all_count=$(uv run find_incomplete_investigations.py | grep -E '^ ' | wc -l)
-hosted_count=$(uv run find_incomplete_investigations.py --hosted-only | grep -E '^ ' | wc -l)
-psql -c "INSERT INTO incomplete_investigation_counts(recorded_at, total, hosted_only) VALUES (now(), $all_count, $hosted_count)"
+all_count=$(uv run find_incomplete_investigations.py | grep -c '^ ')
+hosted_count=$(uv run find_incomplete_investigations.py --hosted-only | grep -c '^ ')
+psql narrative -c "INSERT INTO incomplete_investigation_counts(recorded_at, total, hosted_only) VALUES (now(), $all_count, $hosted_count)"
 
 # Run ensembling
 ./run_ensembling.sh

--- a/cron.sh
+++ b/cron.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+export PGUSER="root"
+export PGDATABASE="narrative"
+
+# Update repository
+git pull -q
+
+# Record incomplete investigation counts
+all_count=$(uv run find_incomplete_investigations.py | grep -E '^ ' | wc -l)
+hosted_count=$(uv run find_incomplete_investigations.py --hosted-only | grep -E '^ ' | wc -l)
+psql -c "INSERT INTO incomplete_investigation_counts(recorded_at, total, hosted_only) VALUES (now(), $all_count, $hosted_count)"
+
+# Run ensembling
+./run_ensembling.sh
+
+# Backup database
+./backup_narrative.sh
+
+# Export website and deploy
+uv run export_website.py
+rsync -av website/ narrative@merah.cassia.ifost.org.au:/var/www/vhosts/narrative-learning.symmachus.org/htdocs/

--- a/postgres-schemas/investigations_schema.sql
+++ b/postgres-schemas/investigations_schema.sql
@@ -85,3 +85,9 @@ CREATE TABLE dataset_provenance (
     dataset TEXT PRIMARY KEY REFERENCES datasets(dataset),
     provenance TEXT NOT NULL
 );
+
+CREATE TABLE incomplete_investigation_counts (
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    total INTEGER NOT NULL,
+    hosted_only INTEGER NOT NULL
+);


### PR DESCRIPTION
## Summary
- Add cron script to update repository, track incomplete investigations, run ensembling, back up DB, build website and deploy
- Track counts of incomplete investigations over time in database
- Generate website page listing incomplete investigations with trend chart and link from index

## Testing
- `uv run pytest`
- `PGUSER=root PGDATABASE=narrative uv run python - <<'PY'
from export_website import generate_incomplete_page, get_connection
import os
conn = get_connection()
os.makedirs('tmp_web', exist_ok=True)
generate_incomplete_page(conn, 'tmp_web/incomplete')
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_688e5d965d8c832581a887a7467a326d