### PR TITLE
Add ignore flag to skip investigations in ensembles and website

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -517,6 +517,7 @@ def generate_dataset_page(
           FROM investigations i
           JOIN models m ON i.model = m.model
          WHERE i.dataset = %s
+           AND NOT i.ignore
          ORDER BY i.id
         """,
         (dataset,),
@@ -969,7 +970,8 @@ def generate_model_page(
         return
     training_model, inference_model = row
     cur.execute(
-        "SELECT id, dataset FROM investigations WHERE model = %s ORDER BY id", (model,)
+        "SELECT id, dataset FROM investigations WHERE model = %s AND NOT ignore ORDER BY id",
+        (model,),
     )
     investigations = cur.fetchall()
     perf_rows: List[Tuple[str, str, str]] = []
@@ -1347,7 +1349,7 @@ def _compute_ensemble_data(
     for model, r_id in zip(models, rounds):
         cur = conn.cursor()
         cur.execute(
-            "SELECT id FROM investigations WHERE dataset=%s AND model=%s",
+            "SELECT id FROM investigations WHERE dataset=%s AND model=%s AND NOT ignore",
             (dataset, model),
         )
         row = cur.fetchone()

--- a/find_incomplete_investigations.py
+++ b/find_incomplete_investigations.py
@@ -4,16 +4,12 @@
 The script verifies that all processed rounds have inference results and
 that early stopping conditions were met.  Early stopping is evaluated
 before flagging missing inference data so investigations that legitimately
-halted early are not reported as incomplete.
+halted early are not reported as incomplete. Investigations marked with
+``ignore`` are skipped.
 """
 import argparse
 from modules.postgres import get_connection
 from modules.investigation_status import gather_incomplete_investigations
-
-
-def gather_missing(conn, hosted_only: bool = False):
-    """Deprecated wrapper for backward compatibility."""
-    return gather_incomplete_investigations(conn, hosted_only=hosted_only)
 
 
 def main() -> None:
@@ -31,7 +27,7 @@ def main() -> None:
     args = parser.parse_args()
 
     conn = get_connection()
-    missing = gather_missing(conn, hosted_only=args.hosted_only)
+    missing = gather_incomplete_investigations(conn, hosted_only=args.hosted_only)
     conn.close()
 
     if not missing:

--- a/modules/investigation_status.py
+++ b/modules/investigation_status.py
@@ -25,6 +25,7 @@ def gather_incomplete_investigations(
               JOIN models m ON i.model = m.model
               JOIN language_models lm ON m.training_model = lm.training_model
              WHERE NOT lm.ollama_hosted
+               AND NOT i.ignore
              ORDER BY i.dataset, i.id
             """
         )
@@ -35,6 +36,7 @@ def gather_incomplete_investigations(
               FROM investigations i
               JOIN datasets d ON i.dataset = d.dataset
               JOIN models m ON i.model = m.model
+             WHERE NOT i.ignore
              ORDER BY i.dataset, i.id
             """
         )

--- a/modules/results_loader.py
+++ b/modules/results_loader.py
@@ -21,6 +21,7 @@ def load_results_dataframe(
           FROM investigations i
           JOIN models m ON i.model = m.model
          WHERE i.dataset = %s
+           AND NOT i.ignore
          ORDER BY i.id
         """,
         (dataset,),

--- a/postgres-schemas/investigations_schema.sql
+++ b/postgres-schemas/investigations_schema.sql
@@ -20,7 +20,8 @@ CREATE TABLE investigations (
     round_tracking_file TEXT,
     dump_file TEXT,
     round_number INTEGER,
-    round_uuid UUID
+    round_uuid UUID,
+    ignore BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE baseline_results (

--- a/results_ensembling.py
+++ b/results_ensembling.py
@@ -776,6 +776,7 @@ if __name__ == '__main__':
           FROM investigations i
           JOIN models m ON i.model = m.model
          WHERE i.dataset = %s
+           AND NOT i.ignore
          ORDER BY i.id
         """,
         (args.dataset,),


### PR DESCRIPTION
## Summary
- Add `ignore` column to the `investigations` table
- Exclude ignored investigations from ensemble building and results loading
- Filter ignored investigations when generating website pages
- Ensure `find_incomplete_investigations.py` skips runs marked ignored

## Testing
- `PGUSER=root uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebd6a5828832581f8576d30f90ca0