### PR TITLE
Reorder baseline labels and refine Herdan plots

### DIFF
--- a/chartutils.py
+++ b/chartutils.py
@@ -27,13 +27,13 @@ def draw_baselines(ax, df, xpos=None, dataset_size=None, debug=None):
         None, modifies ax in-place
     """
     colours = {
-        "logistic regression": "teal",
-        "decision trees": "gold",
         "dummy": "orange",
+        "decision trees": "green",
         "rulefit": "purple",
+        "logistic regression": "teal",
+        "ebm": "gray",
         "bayesian rule list": "brown",
         "corels": "pink",
-        "ebm": "gray",
     }
 
     names = [m for m in colours if m in df.columns]

--- a/results_error_rate_by_herdan.py
+++ b/results_error_rate_by_herdan.py
@@ -83,14 +83,14 @@ def analyze_error_rate_by_herdan(conn, table, dataset, image_output=None,
     
     # Add regression line
     x_range = np.linspace(
-        filtered_df['Herdan Coefficient'].min() - 0.05, 
-        filtered_df['Herdan Coefficient'].max() + 0.25, 
+        filtered_df['Herdan Coefficient'].min() - 0.05,
+        filtered_df['Herdan Coefficient'].max(),
         100
     )
     plt.plot(
-        x_range, 
-        intercept + slope * x_range, 
-        'k--', 
+        x_range,
+        intercept + slope * x_range,
+        'k--',
         linewidth=2,
         label=f'Trend: y = {slope:.4f}x + {intercept:.4f}'
     )


### PR DESCRIPTION
## Summary
- Reorder baseline annotations and switch decision tree color for better contrast
- Drop future extrapolation in Herdan's law charts and lower best-line date label
- Stop Herdan error-rate regression from projecting beyond available data

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689961d8d6f0832583e659e87aaa84dd