### PR TITLE
Add styling for exported website

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -2,7 +2,9 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
+    <link rel="stylesheet" href="{{ style_path }}">
 </head>
 <body>
 <h1>{{ title }}</h1>

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,0 +1,30 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2rem auto;
+    max-width: 800px;
+    line-height: 1.6;
+    background: #fdfdfd;
+    color: #333;
+    padding: 0 1rem;
+}
+
+h1, h2, h3 {
+    color: #2c3e50;
+    line-height: 1.2;
+}
+
+a {
+    color: #0366d6;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 1rem auto;
+}


### PR DESCRIPTION
## Summary
- Add global CSS and responsive meta tag for static website pages
- Copy stylesheet during export and link it to each generated page

## Testing
- `PGUSER=root uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899f80baa0083259164eea777d36112