### PR TITLE
Plot best baseline and move intercept label

### DIFF
--- a/chartutils.py
+++ b/chartutils.py
@@ -13,15 +13,27 @@ import pandas as pd
 from modules.metrics import accuracy_to_kt
 
 
-def draw_baselines(ax, df, xpos=None, dataset_size=None, debug=None):
+def draw_baselines(
+    ax,
+    df,
+    xpos=None,
+    dataset_size=None,
+    debug=None,
+    best_only: bool = False,
+    trend_improving: bool = True,
+):
     """Draw baseline model performance as horizontal lines on a plot.
 
     Args:
         ax: Matplotlib axes object to draw on
         df: DataFrame containing baseline columns
         xpos: If provided, the maximum x-position used to calculate label
-            placement. When ``None``, the function will use the current axis
-            limits to determine label spacing.
+            placement when ``best_only`` is ``False``.  When ``None``, the
+            function will use the current axis limits to determine label
+            spacing.
+        best_only: If ``True``, draw only the best-performing baseline.
+        trend_improving: When ``best_only`` is ``True``, place the label on the
+            right edge of the axis if ``True`` and on the left edge otherwise.
 
     Returns:
         None, modifies ax in-place
@@ -41,33 +53,58 @@ def draw_baselines(ax, df, xpos=None, dataset_size=None, debug=None):
         if debug is not None:
             debug.append("no baseline columns found")
         return
-
-    xlim = ax.get_xlim()
-    if xpos is None:
-        start, end = xlim
-        convert_dates = False
-    else:
-        start, end = xlim[0], xpos
-        convert_dates = isinstance(end, (datetime, pd.Timestamp, np.datetime64))
-
-    if convert_dates:
-        end = mdates.date2num(end)
-    x_positions = np.linspace(start, end, len(names))
-    if convert_dates:
-        x_positions = mdates.num2date(x_positions)
-
-    for model, xpos_val in zip(names, x_positions):
+    scores: dict[str, float] = {}
+    for model in names:
         score = df[model].mean()
         if dataset_size is not None and not math.isnan(score):
             score = -accuracy_to_kt(score, dataset_size)
+        scores[model] = score
+
+    if best_only:
+        best_model = max(scores, key=lambda m: scores[m])
+        names = [best_model]
+
+    xlim = ax.get_xlim()
+    if best_only:
+        x_positions = [xlim[1] if trend_improving else xlim[0]]
+    else:
+        if xpos is None:
+            start, end = xlim
+            convert_dates = False
+        else:
+            start, end = xlim[0], xpos
+            convert_dates = isinstance(end, (datetime, pd.Timestamp, np.datetime64))
+
+        if convert_dates:
+            end = mdates.date2num(end)
+        x_positions = np.linspace(start, end, len(names))
+        if convert_dates:
+            x_positions = mdates.num2date(x_positions)
+
+    for model, xpos_val in zip(names, x_positions):
+        score = scores[model]
         ax.axhline(score, linestyle="dotted", c=colours[model])
         if debug is not None:
             debug.append(f"axhline {model} at {score:.3f}")
-        ax.annotate(
-            xy=(xpos_val, score - 0.03),
-            text=model.title(),
-            c=colours[model],
-            ha="center",
-        )
-        if debug is not None:
-            debug.append(f"annotate {model} at {xpos_val}")
+        if best_only:
+            offset = -5 if trend_improving else 5
+            ha = "right" if trend_improving else "left"
+            ax.annotate(
+                xy=(xpos_val, score - 0.03),
+                text=model.title(),
+                c=colours[model],
+                ha=ha,
+                xytext=(offset, 0),
+                textcoords="offset points",
+            )
+            if debug is not None:
+                debug.append(f"annotate {model} at edge {xpos_val}")
+        else:
+            ax.annotate(
+                xy=(xpos_val, score - 0.03),
+                text=model.title(),
+                c=colours[model],
+                ha="center",
+            )
+            if debug is not None:
+                debug.append(f"annotate {model} at {xpos_val}")

--- a/export_website.py
+++ b/export_website.py
@@ -153,13 +153,6 @@ def plot_release_chart(
     actions.append(f"scatter models: {coords}")
     ax.set_xlabel("Model release date")
     ax.set_ylabel("-log10 KT accuracy")
-    draw_baselines(
-        ax,
-        df,
-        xpos=df["Release Date"].max(),
-        dataset_size=dataset_size,
-        debug=actions,
-    )
 
     ens_df = ens_df.copy()
     ens_df["Release Date"] = pd.to_datetime(ens_df["release_date"], utc=True)
@@ -204,15 +197,27 @@ def plot_release_chart(
     ax.set_xlim(xlim_min, xlim_max)
     actions.append(f"xlim_max {xlim_max.date()}")
 
+    trend_improving = slope > 0
+    draw_baselines(
+        ax,
+        df,
+        dataset_size=dataset_size,
+        debug=actions,
+        best_only=True,
+        trend_improving=trend_improving,
+    )
+
+    y_min, _ = ax.get_ylim()
+
     if cross_date is not None and xlim_min <= cross_date <= xlim_max:
         ax.axvline(cross_date, linestyle=":", color="gray")
         ax.annotate(
             cross_date.strftime("%Y-%m-%d"),
-            xy=(cross_date, best_baseline_y - 0.1),
-            xytext=(0, 5),
+            xy=(cross_date, y_min),
+            xytext=(-5, 0),
             textcoords="offset points",
             rotation=90,
-            ha="center",
+            ha="right",
             va="bottom",
         )
         actions.append("mark baseline crossing")


### PR DESCRIPTION
## Summary
- Display only the best baseline in release charts and align its label based on ensemble trend
- Place the estimated crossover date label at the bottom of the chart

## Testing
- `uv run python -m py_compile export_website.py chartutils.py`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ebca9ea5c8325ab9c61f4dc26d0e0