### PR TITLE
Increase trend line slope precision to six decimals

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -607,7 +607,7 @@ def generate_dataset_page(
         if stats is not None:
             slope, intercept, pval = stats
             body.append(
-                f"<p>Regression slope: {slope:.4f}, intercept: {intercept:.4f}, p-value: {pval:.5g}</p>"
+                f"<p>Regression slope: {slope:.6f}, intercept: {intercept:.4f}, p-value: {pval:.5g}</p>"
             )
         if debug_actions:
             body.append("<h3>Debug</h3>")
@@ -709,7 +709,7 @@ def generate_dataset_page(
             plt.close(fig)
             body.append("<h2>Train vs Validation</h2>")
             body.append("<img src='train_vs_validation.png' alt='train vs validation'>")
-            body.append(f"<p>Regression slope: {slope1:.4f}, intercept: {intercept1:.4f}, p-value: {pval1:.5g}</p>")
+            body.append(f"<p>Regression slope: {slope1:.6f}, intercept: {intercept1:.4f}, p-value: {pval1:.5g}</p>")
 
             # Scatter plot: validation accuracy vs training accuracy
             fig, ax = plt.subplots(figsize=(6, 4))
@@ -729,7 +729,7 @@ def generate_dataset_page(
             plt.close(fig)
             body.append("<h2>Validation vs Train</h2>")
             body.append("<img src='validation_vs_train.png' alt='validation vs train'>")
-            body.append(f"<p>Regression slope: {slope2:.4f}, intercept: {intercept2:.4f}, p-value: {pval2:.5g}</p>")
+            body.append(f"<p>Regression slope: {slope2:.6f}, intercept: {intercept2:.4f}, p-value: {pval2:.5g}</p>")
 
         ens_df = get_interesting_ensembles(conn, dataset)
         if ens_df.empty:
@@ -1228,7 +1228,7 @@ def generate_lexicostatistics_page(conn, out_dir: str) -> dict[str, tuple[float,
         alt_title = f"{law}'s Law ({section})"
         body.append(f"<img src='{fname}' alt='{alt_title} over time'>")
         body.append(
-            f"<p>Slope {slope:.4f}, intercept {intercept:.4f}, p={pval:.5g}</p>"
+            f"<p>Slope {slope:.6f}, intercept {intercept:.4f}, p={pval:.5g}</p>"
         )
         stats[fname] = (slope, intercept, pval)
 
@@ -1343,7 +1343,7 @@ def generate_lexicostatistics_page(conn, out_dir: str) -> dict[str, tuple[float,
         alt_title = f"{law_title} Law ({section})"
         body.append(f"<img src='{fname}' alt='{alt_title} over time'>")
         body.append(
-            f"<p>Slope {slope:.4f}, intercept {intercept:.4f}, p={pval:.5g}</p>"
+            f"<p>Slope {slope:.6f}, intercept {intercept:.4f}, p={pval:.5g}</p>"
         )
         stats[fname] = (slope, intercept, pval)
 
@@ -1618,7 +1618,7 @@ def main() -> None:
         if stats:
             s, i, p = stats
             index_body_parts.append(
-                f"<p>Slope {s:.4f}, intercept {i:.4f}, p={p:.5g}</p>"
+                f"<p>Slope {s:.6f}, intercept {i:.4f}, p={p:.5g}</p>"
             )
     index_body_parts.append("<h2>Lexicostatistics</h2>")
     index_body_parts.append(
@@ -1627,7 +1627,7 @@ def main() -> None:
     s = lex_stats.get("ensemble_prompt_herdan.png") if lex_stats else None
     if s:
         index_body_parts.append(
-            f"<p>Slope {s[0]:.4f}, intercept {s[1]:.4f}, p={s[2]:.5g}</p>"
+            f"<p>Slope {s[0]:.6f}, intercept {s[1]:.4f}, p={s[2]:.5g}</p>"
         )
     index_body_parts.append(
         "<img src='lexicostatistics/ensemble_reasoning_herdan.png' alt='Reasoning vocabulary trend'>"
@@ -1635,7 +1635,7 @@ def main() -> None:
     s = lex_stats.get("ensemble_reasoning_herdan.png") if lex_stats else None
     if s:
         index_body_parts.append(
-            f"<p>Slope {s[0]:.4f}, intercept {s[1]:.4f}, p={s[2]:.5g}</p>"
+            f"<p>Slope {s[0]:.6f}, intercept {s[1]:.4f}, p={s[2]:.5g}</p>"
         )
     index_body_parts.append(
         "<p><a href='dataset/index.html'>Datasets</a> | <a href='model/index.html'>Models</a> | <a href='lexicostatistics/index.html'>Lexicostatistics</a> | <a href='ensemble/index.html'>Ensembles</a> | <a href='incomplete/index.html'>Incomplete</a></p>"

--- a/make_result_charts.py
+++ b/make_result_charts.py
@@ -118,7 +118,7 @@ def plot_log_model_size_vs_log_error(df, output_prefix, baselines, dataset_name)
     intercept = model.params['const']
     p_value = model.pvalues['Log_Model_Size']
     r_squared = model.rsquared
-    print(f"Slope: {slope:.4f}, p-value: {p_value:.4f}")
+    print(f"Slope: {slope:.6f}, p-value: {p_value:.4f}")
     print(f"Intercept: {intercept:.4f}")
     print(f"R-squared: {r_squared:.4f}")
 

--- a/results_chart_by_size.py
+++ b/results_chart_by_size.py
@@ -34,7 +34,7 @@ def plot_log_model_size_vs_log_error(df, output_prefix, dataset_name, pvalue_fil
     intercept = model.params['const']
     p_value = model.pvalues['Log_Model_Size']
     r_squared = model.rsquared
-    print(f"Slope: {slope:.4f}, p-value: {p_value:.4f}")
+    print(f"Slope: {slope:.6f}, p-value: {p_value:.4f}")
     print(f"Intercept: {intercept:.4f}")
     print(f"R-squared: {r_squared:.4f}")
     

--- a/results_error_rate_by_herdan.py
+++ b/results_error_rate_by_herdan.py
@@ -92,7 +92,7 @@ def analyze_error_rate_by_herdan(conn, table, dataset, image_output=None,
         intercept + slope * x_range,
         'k--',
         linewidth=2,
-        label=f'Trend: y = {slope:.4f}x + {intercept:.4f}'
+        label=f'Trend: y = {slope:.6f}x + {intercept:.4f}'
     )
     
     # Add baseline lines
@@ -100,7 +100,7 @@ def analyze_error_rate_by_herdan(conn, table, dataset, image_output=None,
     
     # Add equation and statistics
     equation_text = (
-        f"y = {slope:.4f}x + {intercept:.4f}\n"
+        f"y = {slope:.6f}x + {intercept:.4f}\n"
         f"R² = {r_value**2:.4f}, p = {p_value:.4f}"
     )
     plt.annotate(
@@ -195,7 +195,7 @@ if __name__ == '__main__':
         
         print(f"Analysis completed successfully:")
         print(f"P-value: {p_value:.4f}")
-        print(f"Slope: {slope:.4f}")
+        print(f"Slope: {slope:.6f}")
         print(f"Data points: {len(filtered_df)}")
         
         if args.show:

--- a/results_lexicostatistics_model_trend.py
+++ b/results_lexicostatistics_model_trend.py
@@ -159,12 +159,12 @@ def analyze_model_size_vs_lexical_complexity(conn, table, datasets, output_image
         intercept + slope * x_range, 
         'k--', 
         linewidth=2,
-        label=f'Trend: y = {slope:.4f}x + {intercept:.4f}'
+        label=f'Trend: y = {slope:.6f}x + {intercept:.4f}'
     )
     
     # Add equation and statistics
     equation_text = (
-        f"y = {slope:.4f}x + {intercept:.4f}\n"
+        f"y = {slope:.6f}x + {intercept:.4f}\n"
         f"R² = {r_value**2:.4f}, p = {p_value:.4f}"
     )
     plt.annotate(
@@ -233,7 +233,7 @@ def analyze_model_size_vs_lexical_complexity(conn, table, datasets, output_image
     if latex_output:
         with open(latex_output, 'w') as f:
             # Herdan size trend (slope)
-            f.write(f"\\newcommand{{\\herdansizetrend}}{{{slope:.3f}}}\n")
+            f.write(f"\\newcommand{{\\herdansizetrend}}{{{slope:.6f}}}\n")
             
             # P-value of the trend
             if p_value < 0.001:

--- a/results_wordcount_model_trend.py
+++ b/results_wordcount_model_trend.py
@@ -177,12 +177,12 @@ def analyze_model_size_vs_wordcount(conn, table, datasets, wordcount_type='promp
         intercept + slope * x_range, 
         'k--', 
         linewidth=2,
-        label=f'Trend: y = {slope:.4f}x + {intercept:.4f}'
+        label=f'Trend: y = {slope:.6f}x + {intercept:.4f}'
     )
     
     # Add equation and statistics
     equation_text = (
-        f"y = {slope:.4f}x + {intercept:.4f}\n"
+        f"y = {slope:.6f}x + {intercept:.4f}\n"
         f"R² = {r_value**2:.4f}, p = {p_value:.4f}"
     )
     plt.annotate(
@@ -251,7 +251,7 @@ def analyze_model_size_vs_wordcount(conn, table, datasets, wordcount_type='promp
     if latex_output:
         with open(latex_output, 'w') as f:
             # Size trend (slope)
-            f.write(f"\\newcommand{{\\{latex_prefix}sizetrend}}{{{slope:.3f}}}\n")
+            f.write(f"\\newcommand{{\\{latex_prefix}sizetrend}}{{{slope:.6f}}}\n")
             
             # P-value of the trend
             if p_value < 0.001:


### PR DESCRIPTION
## Summary
- increase slope precision from four to six decimal places across chart and trend outputs
- update LaTeX macro generation to emit the higher-precision slopes
- adjust website export messaging so regression slopes display six decimal places consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd5d207aac8325b2c9fa524efb0754