### PR TITLE
Add dataset summary tables to website index

### DIFF
--- a/templates/style.css
+++ b/templates/style.css
@@ -28,3 +28,22 @@ img {
     display: block;
     margin: 1rem auto;
 }
+
+table.score-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0;
+    font-variant-numeric: tabular-nums;
+}
+
+.score-table th,
+.score-table td {
+    border: 1px solid #d0d7de;
+    padding: 0.5rem;
+    text-align: center;
+}
+
+.score-table th:first-child,
+.score-table td:first-child {
+    text-align: left;
+}


### PR DESCRIPTION
## Summary
- add generation of KT and accuracy summary tables for each dataset on the landing page
- style the summary tables for readability

## Testing
- python -m compileall export_website.py

------
https://chatgpt.com/codex/tasks/task_e_68d154199aa083259e810a736492b42e