### PR TITLE
Add timestamp footer to exported pages

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -45,13 +45,22 @@ _env = Environment(
 _page_template = _env.get_template("page.html")
 
 
+GENERATION_TIME = datetime.now(timezone.utc)
+GENERATION_TIME_DISPLAY = GENERATION_TIME.astimezone(timezone.utc).strftime(
+    "%Y-%m-%d %H:%M:%S %Z"
+)
+
+
 def write_page(path: str, title: str, body: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     style_path = os.path.relpath(
         os.path.join(BASE_DIR, "style.css"), os.path.dirname(path)
     )
     html_content = _page_template.render(
-        title=title, body=body, style_path=style_path
+        title=title,
+        body=body,
+        style_path=style_path,
+        generated_at=GENERATION_TIME_DISPLAY,
     )
     with open(path, "w", encoding="utf-8") as f:
         f.write(html_content)

--- a/templates/page.html
+++ b/templates/page.html
@@ -9,5 +9,6 @@
 <body>
 <h1>{{ title }}</h1>
 {{ body | safe }}
+<footer class="page-footer">Page generated at {{ generated_at }}</footer>
 </body>
 </html>

--- a/templates/style.css
+++ b/templates/style.css
@@ -29,6 +29,15 @@ img {
     margin: 1rem auto;
 }
 
+footer.page-footer {
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid #d0d7de;
+    font-size: 0.9rem;
+    color: #6c757d;
+    text-align: center;
+}
+
 table.score-table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- capture the export timestamp once and pass it into each rendered page
- display the generation timestamp in the shared page template with light footer styling

## Testing
- uv run pytest *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68d23ef5207c8325a35ac584a114e930