### PR TITLE
Fix dataset filter for baseline results query

### DIFF
--- a/export_website.py
+++ b/export_website.py
@@ -1634,7 +1634,7 @@ def main() -> None:
               FROM baseline_results
              WHERE dataset = ANY(%s)
             """,
-            (tuple(dataset_names),),
+            (dataset_names,),
         )
         for row in cur.fetchall():
             dataset = row[0]


### PR DESCRIPTION
## Summary
- pass the list of dataset names directly to the baseline results query so the ANY comparison receives a PostgreSQL array

## Testing
- PGUSER=root PGDATABASE=narrative uv run python export_website.py

------
https://chatgpt.com/codex/tasks/task_e_68d278fa58388325b875ee128fef653b